### PR TITLE
feat(auth): authentication layer (Auth.js + custom reset)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
+# Copy to .env.local and fill in. Never commit .env.local.
+
+# MongoDB connection string. Local dev uses Docker (see README); deploy uses Atlas.
 MONGODB_URI=mongodb://localhost:27017/kboards
+
+# Auth.js. Generate a secret with: openssl rand -base64 32
 AUTH_SECRET=
+# Base URL of the app, used by Auth.js and for password-reset links.
 AUTH_URL=http://localhost:3000
+
+# Transactional email for password resets. Leave SMTP_HOST empty in dev to log
+# the reset link to the console instead of sending mail.
 EMAIL_FROM=
 SMTP_HOST=
 SMTP_PORT=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Authentication layer (see `docs/adr/0004`): Auth.js v5 with a Credentials provider and
+  JWT sessions, a registration Route Handler, and a custom email password-reset flow whose
+  tokens are stored only as SHA-256 hashes and are single use. Route protection moved to a
+  Next.js 16 `proxy` (the renamed Middleware). Covered by Vitest integration tests.
+
 ### Changed
 
 - Began the v2 rebuild: migrating from a Vue/Quasar client plus a standalone Express API

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,4 @@
+import { handlers } from "@/auth";
+
+// Auth.js mounts its endpoints (sign-in, sign-out, session, CSRF) here.
+export const { GET, POST } = handlers;

--- a/app/api/auth/password-reset/confirm/route.ts
+++ b/app/api/auth/password-reset/confirm/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { passwordResetSchema } from "@/lib/validation";
+import { confirmPasswordReset } from "@/lib/auth/passwordReset";
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = passwordResetSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: z.flattenError(parsed.error).fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { userId, token, password } = parsed.data;
+  const result = await confirmPasswordReset(userId, token, password);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: 400 });
+  }
+
+  return NextResponse.json({ message: "Password updated successfully" });
+}

--- a/app/api/auth/password-reset/route.ts
+++ b/app/api/auth/password-reset/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { passwordResetRequestSchema } from "@/lib/validation";
+import { requestPasswordReset } from "@/lib/auth/passwordReset";
+
+// Identical for known and unknown emails, so the response never reveals which
+// addresses have accounts.
+const GENERIC_MESSAGE =
+  "If an account exists for that email, a password reset link has been sent.";
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = passwordResetRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: z.flattenError(parsed.error).fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  await requestPasswordReset(parsed.data.email);
+
+  return NextResponse.json({ message: GENERIC_MESSAGE });
+}

--- a/app/api/auth/register/route.test.ts
+++ b/app/api/auth/register/route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { User } from "@/lib/db/models/User";
+import { POST } from "./route";
+
+function postJson(body: unknown): Request {
+  return new Request("http://localhost/api/auth/register", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  await dbConnect();
+  await User.init();
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+});
+
+describe("POST /api/auth/register", () => {
+  it("creates a user and returns 201 without the password", async () => {
+    const res = await POST(
+      postJson({
+        email: "new@example.com",
+        password: "supersecret",
+        name: "Ada",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.user).toMatchObject({ email: "new@example.com", name: "Ada" });
+    expect(json.user.password).toBeUndefined();
+    expect(await User.countDocuments()).toBe(1);
+  });
+
+  it("rejects a duplicate email with 409", async () => {
+    await User.create({ email: "dupe@example.com", password: "supersecret" });
+
+    const res = await POST(
+      postJson({ email: "dupe@example.com", password: "supersecret" }),
+    );
+
+    expect(res.status).toBe(409);
+    expect(await User.countDocuments()).toBe(1);
+  });
+
+  it("treats email as case-insensitive when detecting duplicates", async () => {
+    await User.create({ email: "dupe@example.com", password: "supersecret" });
+
+    const res = await POST(
+      postJson({ email: "DUPE@Example.com", password: "supersecret" }),
+    );
+
+    expect(res.status).toBe(409);
+    expect(await User.countDocuments()).toBe(1);
+  });
+
+  it("rejects invalid input with 400", async () => {
+    const res = await POST(
+      postJson({ email: "not-an-email", password: "short" }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Validation failed");
+  });
+
+  it("rejects a non-JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/auth/register", {
+        method: "POST",
+        body: "not json",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { dbConnect } from "@/lib/db/mongoose";
+import { User } from "@/lib/db/models/User";
+import { registerSchema } from "@/lib/validation";
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = registerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: z.flattenError(parsed.error).fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  const email = parsed.data.email.trim().toLowerCase();
+  const { password, name } = parsed.data;
+  await dbConnect();
+
+  // Pre-check for a friendly 409 rather than surfacing a raw duplicate-key
+  // error. The unique index on email remains the source of truth against races.
+  const existing = await User.findOne({ email });
+  if (existing) {
+    return NextResponse.json(
+      { error: "An account with that email already exists" },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const user = await User.create({ email, password, name });
+    return NextResponse.json(
+      { user: { id: String(user._id), email: user.email, name: user.name } },
+      { status: 201 },
+    );
+  } catch (err) {
+    // A concurrent request can still win the race; the unique index catches it.
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === 11000
+    ) {
+      return NextResponse.json(
+        { error: "An account with that email already exists" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,38 @@
+import type { NextAuthConfig } from "next-auth";
+
+// Route prefixes that require an authenticated user. Everything else is public.
+const PROTECTED_PREFIXES = ["/boards"];
+
+// Database- and adapter-free configuration shared by the full auth instance
+// (`auth.ts`) and the proxy (`proxy.ts`). Keeping the Credentials provider and
+// its Mongoose lookup out of this file lets the proxy read sessions without
+// pulling the database layer into every request.
+export const authConfig = {
+  pages: {
+    signIn: "/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    // Gate used by the proxy. Returning false redirects the visitor to the
+    // sign-in page; returning true lets the request through.
+    authorized({ auth, request: { nextUrl } }) {
+      const isLoggedIn = Boolean(auth?.user);
+      const isProtected = PROTECTED_PREFIXES.some((prefix) =>
+        nextUrl.pathname.startsWith(prefix),
+      );
+      if (isProtected) return isLoggedIn;
+      return true;
+    },
+    // Auth.js stores the signed-in user's id in the JWT `sub` claim. Surface it
+    // on the session so the app can read the current user's id.
+    session({ session, token }) {
+      if (token.sub) session.user.id = token.sub;
+      return session;
+    },
+  },
+  providers: [],
+} satisfies NextAuthConfig;
+
+export default authConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,25 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import { authConfig } from "./auth.config";
+import { loginSchema } from "@/lib/validation";
+import { verifyCredentials } from "@/lib/auth/credentials";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  ...authConfig,
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      // Auth.js does not validate credential input, so validate here before
+      // touching the database. Returning null yields a generic sign-in error.
+      authorize: async (credentials) => {
+        const parsed = loginSchema.safeParse(credentials);
+        if (!parsed.success) return null;
+        const { email, password } = parsed.data;
+        return verifyCredentials(email, password);
+      },
+    }),
+  ],
+});

--- a/lib/auth/credentials.test.ts
+++ b/lib/auth/credentials.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { User } from "@/lib/db/models/User";
+import { verifyCredentials } from "./credentials";
+
+beforeAll(async () => {
+  await dbConnect();
+  await User.init();
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+});
+
+describe("verifyCredentials", () => {
+  it("returns the safe user for a correct email and password", async () => {
+    await User.create({
+      email: "user@example.com",
+      password: "supersecret",
+      name: "Ada",
+    });
+
+    const result = await verifyCredentials("user@example.com", "supersecret");
+
+    expect(result).toEqual({
+      id: expect.any(String),
+      email: "user@example.com",
+      name: "Ada",
+    });
+  });
+
+  it("matches regardless of the email's case or surrounding space", async () => {
+    await User.create({ email: "user@example.com", password: "supersecret" });
+
+    const result = await verifyCredentials("  USER@Example.com ", "supersecret");
+
+    expect(result).not.toBeNull();
+    expect(result?.email).toBe("user@example.com");
+  });
+
+  it("returns null for a wrong password", async () => {
+    await User.create({ email: "user@example.com", password: "supersecret" });
+
+    expect(
+      await verifyCredentials("user@example.com", "wrong-password"),
+    ).toBeNull();
+  });
+
+  it("returns null for an unknown email", async () => {
+    expect(
+      await verifyCredentials("nobody@example.com", "whatever123"),
+    ).toBeNull();
+  });
+});

--- a/lib/auth/credentials.ts
+++ b/lib/auth/credentials.ts
@@ -1,0 +1,33 @@
+import bcrypt from "bcryptjs";
+import { dbConnect } from "@/lib/db/mongoose";
+import { User } from "@/lib/db/models/User";
+
+export interface AuthedUser {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+// Verifies an email/password pair against the database and returns the safe
+// user shape, or null on any failure. Callers must not reveal which check
+// failed (unknown user vs wrong password) to avoid user enumeration.
+export async function verifyCredentials(
+  email: string,
+  password: string,
+): Promise<AuthedUser | null> {
+  await dbConnect();
+
+  // Emails are stored lowercase/trimmed, so normalize the lookup to match.
+  const normalizedEmail = email.trim().toLowerCase();
+
+  // Password is select:false on the schema, so request it explicitly here.
+  const user = await User.findOne({ email: normalizedEmail }).select(
+    "+password",
+  );
+  if (!user) return null;
+
+  const passwordMatches = await bcrypt.compare(password, user.password);
+  if (!passwordMatches) return null;
+
+  return { id: String(user._id), email: user.email, name: user.name };
+}

--- a/lib/auth/dal.ts
+++ b/lib/auth/dal.ts
@@ -1,0 +1,9 @@
+import { auth } from "@/auth";
+
+// Data access helper: returns the signed-in user's id, or null. Route Handlers
+// and Server Components call this to enforce authorization close to the data,
+// following the Next.js Data Access Layer guidance.
+export async function getCurrentUserId(): Promise<string | null> {
+  const session = await auth();
+  return session?.user?.id ?? null;
+}

--- a/lib/auth/passwordReset.test.ts
+++ b/lib/auth/passwordReset.test.ts
@@ -1,0 +1,152 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import crypto from "crypto";
+import bcrypt from "bcryptjs";
+import mongoose from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { User } from "@/lib/db/models/User";
+import { Token } from "@/lib/db/models/Token";
+import {
+  requestPasswordReset,
+  confirmPasswordReset,
+} from "./passwordReset";
+
+// Capture the reset link instead of sending an email.
+vi.mock("@/lib/email", () => ({ sendResetEmail: vi.fn() }));
+import { sendResetEmail } from "@/lib/email";
+const sendResetEmailMock = vi.mocked(sendResetEmail);
+
+// The raw token is the last path segment of the link handed to sendResetEmail.
+function lastEmailedToken(): string {
+  const call = sendResetEmailMock.mock.calls.at(-1);
+  if (!call) throw new Error("sendResetEmail was not called");
+  return call[1].split("/").pop()!;
+}
+
+beforeAll(async () => {
+  await dbConnect();
+  await User.init();
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  await Token.deleteMany({});
+  vi.clearAllMocks();
+});
+
+describe("requestPasswordReset", () => {
+  it("stores only a hash of the token and emails the raw link", async () => {
+    await User.create({ email: "user@example.com", password: "supersecret" });
+
+    await requestPasswordReset("user@example.com");
+
+    const tokens = await Token.find({});
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].tokenHash).toMatch(/^[a-f0-9]{64}$/);
+
+    const rawToken = lastEmailedToken();
+    const expectedHash = crypto
+      .createHash("sha256")
+      .update(rawToken)
+      .digest("hex");
+    expect(expectedHash).toBe(tokens[0].tokenHash);
+  });
+
+  it("does nothing and reveals nothing for an unknown email", async () => {
+    await requestPasswordReset("nobody@example.com");
+
+    expect(await Token.countDocuments()).toBe(0);
+    expect(sendResetEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a single active token per user across requests", async () => {
+    const user = await User.create({
+      email: "user@example.com",
+      password: "supersecret",
+    });
+
+    await requestPasswordReset("user@example.com");
+    await requestPasswordReset("user@example.com");
+
+    expect(await Token.countDocuments({ userId: user._id })).toBe(1);
+  });
+});
+
+describe("confirmPasswordReset", () => {
+  it("updates the password with a valid token and burns it", async () => {
+    const user = await User.create({
+      email: "user@example.com",
+      password: "supersecret",
+    });
+    await requestPasswordReset("user@example.com");
+    const rawToken = lastEmailedToken();
+
+    const result = await confirmPasswordReset(
+      String(user._id),
+      rawToken,
+      "newpassword1",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(await Token.countDocuments()).toBe(0);
+
+    const updated = await User.findById(user._id).select("+password");
+    expect(await bcrypt.compare("newpassword1", updated!.password)).toBe(true);
+  });
+
+  it("cannot be replayed once used", async () => {
+    const user = await User.create({
+      email: "user@example.com",
+      password: "supersecret",
+    });
+    await requestPasswordReset("user@example.com");
+    const rawToken = lastEmailedToken();
+
+    await confirmPasswordReset(String(user._id), rawToken, "newpassword1");
+    const replay = await confirmPasswordReset(
+      String(user._id),
+      rawToken,
+      "anotherpass2",
+    );
+
+    expect(replay.ok).toBe(false);
+  });
+
+  it("rejects an invalid token", async () => {
+    const user = await User.create({
+      email: "user@example.com",
+      password: "supersecret",
+    });
+    await requestPasswordReset("user@example.com");
+
+    const result = await confirmPasswordReset(
+      String(user._id),
+      "deadbeef",
+      "newpassword1",
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a malformed user id without throwing", async () => {
+    const result = await confirmPasswordReset(
+      "not-an-objectid",
+      "deadbeef",
+      "newpassword1",
+    );
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/lib/auth/passwordReset.ts
+++ b/lib/auth/passwordReset.ts
@@ -1,0 +1,68 @@
+import crypto from "crypto";
+import mongoose from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { User } from "@/lib/db/models/User";
+import { Token } from "@/lib/db/models/Token";
+import { sendResetEmail } from "@/lib/email";
+
+// SHA-256 hash used to store reset tokens at rest. The raw token is only ever
+// emailed to the user, so a database leak exposes no usable tokens.
+function hashToken(rawToken: string): string {
+  return crypto.createHash("sha256").update(rawToken).digest("hex");
+}
+
+// Issues a password reset for the given email. Resolves identically whether or
+// not the email maps to an account, so the caller can return a generic response
+// and avoid revealing which addresses are registered.
+export async function requestPasswordReset(email: string): Promise<void> {
+  await dbConnect();
+
+  const user = await User.findOne({ email: email.trim().toLowerCase() });
+  if (!user) return;
+
+  const rawToken = crypto.randomBytes(32).toString("hex");
+
+  // One active token per user: replace any existing one and reset its TTL clock
+  // (the Token model expires documents an hour after createdAt).
+  await Token.findOneAndUpdate(
+    { userId: user._id },
+    { userId: user._id, tokenHash: hashToken(rawToken), createdAt: new Date() },
+    { upsert: true },
+  );
+
+  const baseUrl = process.env.AUTH_URL ?? "http://localhost:3000";
+  const link = `${baseUrl}/password-reset/${String(user._id)}/${rawToken}`;
+  await sendResetEmail(user.email, link);
+}
+
+export type ConfirmResult = { ok: true } | { ok: false; reason: string };
+
+const INVALID = "Invalid or expired reset link";
+
+// Completes a password reset: validates the token by its hash (a TTL index has
+// already removed expired ones), updates the password, and burns the token so
+// the link cannot be replayed.
+export async function confirmPasswordReset(
+  userId: string,
+  rawToken: string,
+  newPassword: string,
+): Promise<ConfirmResult> {
+  await dbConnect();
+
+  // Guard before casting so a malformed id is a clean rejection, not a 500.
+  if (!mongoose.isValidObjectId(userId)) return { ok: false, reason: INVALID };
+
+  const token = await Token.findOne({ userId, tokenHash: hashToken(rawToken) });
+  if (!token) return { ok: false, reason: INVALID };
+
+  const user = await User.findById(userId).select("+password");
+  if (!user) return { ok: false, reason: INVALID };
+
+  // Assigning triggers the User pre-save hook, which hashes the new password.
+  user.password = newPassword;
+  await user.save();
+
+  await Token.deleteOne({ _id: token._id });
+
+  return { ok: true };
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,33 @@
+import nodemailer from "nodemailer";
+
+const FROM = process.env.EMAIL_FROM || "kboards <no-reply@kboards.local>";
+
+// Sends the password reset link. When SMTP is configured we deliver a real
+// email; otherwise (local dev, CI) we log the link so the flow stays testable
+// end to end without external credentials. Wiring a transactional provider for
+// production is a follow-up (see docs/adr/0004).
+export async function sendResetEmail(to: string, link: string): Promise<void> {
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env;
+
+  if (!SMTP_HOST) {
+    console.info(`[email] password reset for ${to}: ${link}`);
+    return;
+  }
+
+  const port = Number(SMTP_PORT) || 587;
+  const transport = nodemailer.createTransport({
+    host: SMTP_HOST,
+    port,
+    secure: port === 465,
+    auth: SMTP_USER ? { user: SMTP_USER, pass: SMTP_PASS } : undefined,
+  });
+
+  await transport.sendMail({
+    from: FROM,
+    to,
+    subject: "Reset your kboards password",
+    text:
+      `Reset your kboards password using this link:\n\n${link}\n\n` +
+      `This link expires in one hour. If you did not request it, you can ignore this email.`,
+  });
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,15 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+// Next.js 16 renamed Middleware to Proxy. Reuse the database-free config so the
+// proxy can read the session and run the `authorized` callback without bundling
+// the Credentials provider or Mongoose. Auth.js returns an `auth` function that
+// is itself the proxy handler.
+const { auth } = NextAuth(authConfig);
+
+export default auth;
+
+export const config = {
+  // Run on everything except API routes, Next internals, and static files.
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\.png$).*)"],
+};

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,12 @@
+import type { DefaultSession } from "next-auth";
+
+// Expose the user's MongoDB id on the session (it is carried in the JWT `sub`
+// claim and copied across in the session callback) so Server Components, Route
+// Handlers, and the proxy can read it.
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,26 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    // Mirror the tsconfig `@/*` path alias so tests resolve app imports.
+    alias: { "@": root },
+  },
   test: {
     environment: "node",
     include: ["**/*.test.ts"],
     exclude: ["legacy/**", "node_modules/**", ".next/**"],
+    // Integration tests share one MongoDB database and reset it between cases.
+    // Run test files one at a time so their setup/teardown cannot race.
+    fileParallelism: false,
+    // Integration tests talk to a local MongoDB; default to a throwaway db.
+    env: {
+      MONGODB_URI:
+        process.env.MONGODB_URI ?? "mongodb://localhost:27017/kboards-test",
+    },
     passWithNoTests: true,
   },
 });


### PR DESCRIPTION
## Problem

The v2 rebuild has a data layer but no way to sign in. We need authentication, registration, route protection, and a password-reset flow before any board UI can be built. v1 used custom Express JWT auth plus an email reset flow; that has to be rebuilt for Next.js.

## Approach

Adopt Auth.js v5 (per ADR 0004) and layer a custom reset flow alongside it.

- **Credentials + JWT.** Email/password via the Credentials provider, JWT session strategy. Config is split into a database-free `auth.config.ts` (shared by the full instance and the proxy) and `auth.ts` (the Credentials provider with the Mongoose lookup). The user id rides in the JWT `sub` claim and is surfaced on `session.user.id`.
- **Route protection via `proxy.ts`.** Next.js 16 renamed Middleware to Proxy; `/boards` is gated on a session through the `authorized` callback.
- **Registration handler.** zod-validated, case-insensitive duplicate check backed by the unique index (with an 11000 race fallback), never echoes the password.
- **Custom reset flow.** Auth.js does not provide password reset. Reset tokens are stored only as SHA-256 hashes, are single use, and expire via the existing TTL index. The request endpoint always responds identically to avoid user enumeration. Delivery uses nodemailer, falling back to logging the link in dev so the flow works without SMTP.

## Tradeoffs / alternatives considered

- **Auth.js vs. porting the custom JWT.** Porting was rejected: Auth.js gives maintained session/CSRF/cookie handling and a path to OAuth later (ADR 0004). Cost: the Credentials provider is the least batteries-included path, so login/registration/reset are covered by tests.
- **MongoDB adapter deferred.** Credentials + JWT does not persist users through an adapter, so wiring it now would be dead code. Users are created and read directly through Mongoose; the adapter lands with OAuth.
- **`token.sub` instead of a custom `token.id` claim.** Auth.js already stores the user id in `sub`, so a custom claim plus a JWT type augmentation was redundant. Dropped it.
- **Email delivery stubbed in dev.** Real transactional email needs a provider and credentials; out of scope here. The nodemailer-or-log split keeps the reset flow end-to-end testable now, with the provider as a follow-up.
- **Reset tokens hashed at rest.** v1 stored the raw token. Hashing means a database leak exposes no usable tokens, at the cost of a hash on each verify.
- **Serial test execution.** The integration tests share one MongoDB database; running files serially is simpler and more honest than spinning a database per file.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` all clean (4 auth routes + proxy registered).
- `npm test`: 20 passing. New integration tests against a local MongoDB cover `verifyCredentials`, the registration handler (201 / 409 incl. different-case / 400), and the reset flow (hash-only storage, emailed token matches the stored hash, no-op for unknown emails, one active token per user, single-use burn, replay and malformed-id rejection).
- No UI in this slice, so no screenshots; sign-in is exercised end to end in the UI slice.

https://claude.ai/code/session_01R1FckjFUQVsxm5z5UjmU6U