### PR TITLE
feat(boards): board and task CRUD API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Board and task API: CRUD Route Handlers for boards, columns, tasks, and subtasks,
+  backed by an ownership-scoped service layer and a shared authenticated-route wrapper
+  (one auth gate and one error-mapping policy). Improves on v1 by adding board rename and
+  delete, which the old API lacked. Covered by Vitest integration tests.
 - Authentication layer (see `docs/adr/0004`): Auth.js v5 with a Credentials provider and
   JWT sessions, a registration Route Handler, and a custom email password-reset flow whose
   tokens are stored only as SHA-256 hashes and are single use. Route protection moved to a

--- a/app/api/boards/[boardId]/columns/[columnId]/route.ts
+++ b/app/api/boards/[boardId]/columns/[columnId]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { columnUpdateSchema } from "@/lib/validation";
+import { updateColumn, deleteColumn } from "@/lib/services/boards";
+
+type Params = { boardId: string; columnId: string };
+
+export const PATCH = authed<Params>(async ({ request, userId, params }) => {
+  const input = columnUpdateSchema.parse(await readJson(request));
+  const board = await updateColumn(
+    userId,
+    params.boardId,
+    params.columnId,
+    input,
+  );
+  return NextResponse.json({ board });
+});
+
+export const DELETE = authed<Params>(async ({ userId, params }) => {
+  const board = await deleteColumn(userId, params.boardId, params.columnId);
+  return NextResponse.json({ board });
+});

--- a/app/api/boards/[boardId]/columns/route.ts
+++ b/app/api/boards/[boardId]/columns/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { columnSchema } from "@/lib/validation";
+import { addColumn } from "@/lib/services/boards";
+
+type Params = { boardId: string };
+
+export const POST = authed<Params>(async ({ request, userId, params }) => {
+  const input = columnSchema.parse(await readJson(request));
+  const board = await addColumn(userId, params.boardId, input);
+  return NextResponse.json({ board }, { status: 201 });
+});

--- a/app/api/boards/[boardId]/route.ts
+++ b/app/api/boards/[boardId]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { boardUpdateSchema } from "@/lib/validation";
+import { getBoard, updateBoard, deleteBoard } from "@/lib/services/boards";
+
+type Params = { boardId: string };
+
+export const GET = authed<Params>(async ({ userId, params }) => {
+  const board = await getBoard(userId, params.boardId);
+  return NextResponse.json({ board });
+});
+
+export const PATCH = authed<Params>(async ({ request, userId, params }) => {
+  const input = boardUpdateSchema.parse(await readJson(request));
+  const board = await updateBoard(userId, params.boardId, input);
+  return NextResponse.json({ board });
+});
+
+export const DELETE = authed<Params>(async ({ userId, params }) => {
+  await deleteBoard(userId, params.boardId);
+  return new NextResponse(null, { status: 204 });
+});

--- a/app/api/boards/[boardId]/tasks/[taskId]/route.ts
+++ b/app/api/boards/[boardId]/tasks/[taskId]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { taskUpdateSchema } from "@/lib/validation";
+import { updateTask, deleteTask } from "@/lib/services/tasks";
+
+type Params = { boardId: string; taskId: string };
+
+export const PATCH = authed<Params>(async ({ request, userId, params }) => {
+  const input = taskUpdateSchema.parse(await readJson(request));
+  const board = await updateTask(userId, params.boardId, params.taskId, input);
+  return NextResponse.json({ board });
+});
+
+export const DELETE = authed<Params>(async ({ userId, params }) => {
+  const board = await deleteTask(userId, params.boardId, params.taskId);
+  return NextResponse.json({ board });
+});

--- a/app/api/boards/[boardId]/tasks/[taskId]/subtasks/[subtaskId]/route.ts
+++ b/app/api/boards/[boardId]/tasks/[taskId]/subtasks/[subtaskId]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { subtaskUpdateSchema } from "@/lib/validation";
+import { updateSubtask } from "@/lib/services/tasks";
+
+type Params = { boardId: string; taskId: string; subtaskId: string };
+
+export const PATCH = authed<Params>(async ({ request, userId, params }) => {
+  const input = subtaskUpdateSchema.parse(await readJson(request));
+  const board = await updateSubtask(
+    userId,
+    params.boardId,
+    params.taskId,
+    params.subtaskId,
+    input,
+  );
+  return NextResponse.json({ board });
+});

--- a/app/api/boards/[boardId]/tasks/route.ts
+++ b/app/api/boards/[boardId]/tasks/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { taskSchema } from "@/lib/validation";
+import { createTask } from "@/lib/services/tasks";
+
+type Params = { boardId: string };
+
+export const POST = authed<Params>(async ({ request, userId, params }) => {
+  const input = taskSchema.parse(await readJson(request));
+  const board = await createTask(userId, params.boardId, input);
+  return NextResponse.json({ board }, { status: 201 });
+});

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { boardSchema } from "@/lib/validation";
+import { listBoards, createBoard } from "@/lib/services/boards";
+
+export const GET = authed(async ({ userId }) => {
+  const boards = await listBoards(userId);
+  return NextResponse.json({ boards });
+});
+
+export const POST = authed(async ({ request, userId }) => {
+  const input = boardSchema.parse(await readJson(request));
+  const board = await createBoard(userId, input);
+  return NextResponse.json({ board }, { status: 201 });
+});

--- a/lib/api/route.test.ts
+++ b/lib/api/route.test.ts
@@ -55,7 +55,7 @@ describe("authed", () => {
     expect(await res.json()).toEqual({ error: "Board not found" });
   });
 
-  it("maps a ZodError to 400", async () => {
+  it("maps a ZodError to 400 with per-field details", async () => {
     mockUser.mockResolvedValue("user-1");
     const schema = z.object({ name: z.string() });
     const handler = authed(async () => {
@@ -66,6 +66,53 @@ describe("authed", () => {
     const res = await handler(postRequest(), context({}));
 
     expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Validation failed");
+    expect(json.details.name).toBeInstanceOf(Array);
+    expect(json.details.formErrors).toBeInstanceOf(Array);
+  });
+
+  it("reports object-level refine failures via formErrors", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const schema = z
+      .object({ a: z.string().optional() })
+      .refine((data) => data.a !== undefined, { message: "provide a" });
+    const handler = authed(async () => {
+      schema.parse({});
+      return NextResponse.json({ ok: true });
+    });
+
+    const res = await handler(postRequest(), context({}));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).details.formErrors).toContain("provide a");
+  });
+
+  it("maps a Mongoose ValidationError to 400", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const handler = authed(async () => {
+      const error = new Error("Path `name` is required.");
+      error.name = "ValidationError";
+      throw error;
+    });
+
+    const res = await handler(postRequest(), context({}));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("maps an unexpected error to 500 and logs it", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = authed(async () => {
+      throw new Error("boom");
+    });
+
+    const res = await handler(postRequest(), context({}));
+
+    expect(res.status).toBe(500);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it("treats a malformed JSON body as 400 via readJson", async () => {

--- a/lib/api/route.test.ts
+++ b/lib/api/route.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+// Mock the data-access helper so the wrapper never touches Auth.js or the db.
+vi.mock("@/lib/auth/dal", () => ({ getCurrentUserId: vi.fn() }));
+import { getCurrentUserId } from "@/lib/auth/dal";
+import { authed, readJson } from "./route";
+import { notFound } from "@/lib/services/errors";
+
+const mockUser = vi.mocked(getCurrentUserId);
+
+function context<P>(params: P) {
+  return { params: Promise.resolve(params) };
+}
+function postRequest(body?: string) {
+  return new Request("http://localhost/api/x", { method: "POST", body });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("authed", () => {
+  it("returns 401 when there is no signed-in user", async () => {
+    mockUser.mockResolvedValue(null);
+    const handler = authed(async () => NextResponse.json({ ok: true }));
+
+    const res = await handler(postRequest(), context({}));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("passes the user id and resolved params to the handler", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const handler = authed<{ boardId: string }>(async ({ userId, params }) =>
+      NextResponse.json({ userId, boardId: params.boardId }),
+    );
+
+    const res = await handler(postRequest(), context({ boardId: "b1" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ userId: "user-1", boardId: "b1" });
+  });
+
+  it("maps a ServiceError to its status and message", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const handler = authed(async () => {
+      throw notFound("Board not found");
+    });
+
+    const res = await handler(postRequest(), context({}));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Board not found" });
+  });
+
+  it("maps a ZodError to 400", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const schema = z.object({ name: z.string() });
+    const handler = authed(async () => {
+      schema.parse({});
+      return NextResponse.json({ ok: true });
+    });
+
+    const res = await handler(postRequest(), context({}));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("treats a malformed JSON body as 400 via readJson", async () => {
+    mockUser.mockResolvedValue("user-1");
+    const handler = authed(async ({ request }) => {
+      await readJson(request);
+      return NextResponse.json({ ok: true });
+    });
+
+    const res = await handler(postRequest("not json"), context({}));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/lib/api/route.ts
+++ b/lib/api/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { z, ZodError } from "zod";
+import { getCurrentUserId } from "@/lib/auth/dal";
+import { ServiceError } from "@/lib/services/errors";
+
+interface AuthedArgs<P> {
+  request: Request;
+  userId: string;
+  params: P;
+}
+
+// Wraps a Route Handler so every authenticated route shares one auth gate and
+// one error-mapping policy. The handler receives the verified user id and the
+// resolved route params, and may throw ServiceError or ZodError to produce
+// non-200 responses.
+export function authed<P = Record<string, never>>(
+  handler: (args: AuthedArgs<P>) => Promise<Response>,
+) {
+  return async (
+    request: Request,
+    context: { params: Promise<P> },
+  ): Promise<Response> => {
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    try {
+      const params = await context.params;
+      return await handler({ request, userId, params });
+    } catch (error) {
+      return toErrorResponse(error);
+    }
+  };
+}
+
+// Parses a JSON request body, throwing a 400 on malformed input.
+export async function readJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    throw new ServiceError(400, "Request body must be valid JSON");
+  }
+}
+
+function toErrorResponse(error: unknown): NextResponse {
+  if (error instanceof ServiceError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status },
+    );
+  }
+  if (error instanceof ZodError) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: z.flattenError(error).fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+  // Mongoose schema validation (e.g. a field below its minlength) is a 400.
+  if (
+    error &&
+    typeof error === "object" &&
+    (error as { name?: string }).name === "ValidationError"
+  ) {
+    return NextResponse.json({ error: "Validation failed" }, { status: 400 });
+  }
+  console.error("Unhandled route error:", error);
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+}

--- a/lib/api/route.ts
+++ b/lib/api/route.ts
@@ -20,11 +20,13 @@ export function authed<P = Record<string, never>>(
     request: Request,
     context: { params: Promise<P> },
   ): Promise<Response> => {
-    const userId = await getCurrentUserId();
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
     try {
+      // Inside the try so a session/db failure here is mapped and logged like
+      // any other error rather than escaping the wrapper.
+      const userId = await getCurrentUserId();
+      if (!userId) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
       const params = await context.params;
       return await handler({ request, userId, params });
     } catch (error) {
@@ -50,10 +52,13 @@ function toErrorResponse(error: unknown): NextResponse {
     );
   }
   if (error instanceof ZodError) {
+    // Include formErrors so object-level .refine failures (e.g. "provide at
+    // least one field") are reported, not just per-field errors.
+    const flattened = z.flattenError(error);
     return NextResponse.json(
       {
         error: "Validation failed",
-        details: z.flattenError(error).fieldErrors,
+        details: { ...flattened.fieldErrors, formErrors: flattened.formErrors },
       },
       { status: 400 },
     );

--- a/lib/db/models/Board.ts
+++ b/lib/db/models/Board.ts
@@ -1,36 +1,40 @@
-import mongoose, { Schema, type Model } from "mongoose";
+import mongoose, { Schema, type Model, type Types } from "mongoose";
 
+// `_id` is optional on the interfaces so plain objects can be pushed onto the
+// document arrays (Mongoose generates the id); it is always present when read.
+// The arrays are typed as DocumentArray so services can use `.id()` / `.pull()`.
 export interface IColumn {
-  _id: mongoose.Types.ObjectId;
+  _id?: Types.ObjectId;
   name: string;
   color: string;
 }
 
 export interface IStatus {
   name: string;
-  color: string;
+  // Defaults to "" in the schema, so it is optional on input.
+  color?: string;
 }
 
 export interface ISubtask {
-  _id: mongoose.Types.ObjectId;
+  _id?: Types.ObjectId;
   title: string;
   completed: boolean;
 }
 
 export interface ITask {
-  _id: mongoose.Types.ObjectId;
+  _id?: Types.ObjectId;
   title: string;
   description?: string;
   status: IStatus;
-  subtasks: ISubtask[];
+  subtasks: Types.DocumentArray<ISubtask>;
 }
 
 export interface IBoard {
   name: string;
   description?: string;
-  createdBy: mongoose.Types.ObjectId;
-  columns: IColumn[];
-  tasks: ITask[];
+  createdBy: Types.ObjectId;
+  columns: Types.DocumentArray<IColumn>;
+  tasks: Types.DocumentArray<ITask>;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/lib/services/access.ts
+++ b/lib/services/access.ts
@@ -1,0 +1,18 @@
+import { isValidObjectId, type HydratedDocument } from "mongoose";
+import { Board, type IBoard } from "@/lib/db/models/Board";
+import { notFound } from "./errors";
+
+export type BoardDocument = HydratedDocument<IBoard>;
+
+// Loads a board only if it belongs to the user. An invalid id is treated as
+// "not found" so callers never leak the difference, and a malformed id can
+// never reach Mongoose as a cast error.
+export async function findOwnedBoard(
+  userId: string,
+  boardId: string,
+): Promise<BoardDocument> {
+  if (!isValidObjectId(boardId)) throw notFound("Board not found");
+  const board = await Board.findOne({ _id: boardId, createdBy: userId });
+  if (!board) throw notFound("Board not found");
+  return board;
+}

--- a/lib/services/boards.test.ts
+++ b/lib/services/boards.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { Board } from "@/lib/db/models/Board";
+import { ServiceError } from "@/lib/services/errors";
+import {
+  listBoards,
+  getBoard,
+  createBoard,
+  updateBoard,
+  deleteBoard,
+  addColumn,
+  updateColumn,
+  deleteColumn,
+} from "@/lib/services/boards";
+
+const newId = () => new mongoose.Types.ObjectId().toString();
+
+// Runs a rejecting call once and returns the ServiceError status it threw.
+async function rejectionStatus(promise: Promise<unknown>): Promise<number> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof ServiceError) return error.status;
+    throw error;
+  }
+  throw new Error("Expected the call to reject, but it resolved");
+}
+
+beforeAll(async () => {
+  await dbConnect();
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  await Board.deleteMany({});
+});
+
+describe("board CRUD", () => {
+  it("creates a board owned by the user", async () => {
+    const userId = newId();
+    const board = await createBoard(userId, { name: "Roadmap" });
+    expect(board.name).toBe("Roadmap");
+    expect(String(board.createdBy)).toBe(userId);
+    expect(board.columns).toHaveLength(0);
+  });
+
+  it("lists only the requesting user's boards", async () => {
+    const userId = newId();
+    const otherId = newId();
+    await createBoard(userId, { name: "Mine" });
+    await createBoard(otherId, { name: "Theirs" });
+
+    const boards = await listBoards(userId);
+
+    expect(boards).toHaveLength(1);
+    expect(boards[0].name).toBe("Mine");
+  });
+
+  it("gets an owned board and hides others as not found", async () => {
+    const userId = newId();
+    const created = await createBoard(userId, { name: "Mine" });
+
+    const fetched = await getBoard(userId, String(created._id));
+    expect(fetched.name).toBe("Mine");
+
+    expect(await rejectionStatus(getBoard(newId(), String(created._id)))).toBe(
+      404,
+    );
+  });
+
+  it("treats a malformed or missing board id as not found", async () => {
+    expect(await rejectionStatus(getBoard(newId(), "not-an-id"))).toBe(404);
+    expect(await rejectionStatus(getBoard(newId(), newId()))).toBe(404);
+  });
+
+  it("renames a board and refuses non-owners", async () => {
+    const userId = newId();
+    const board = await createBoard(userId, { name: "Old" });
+
+    const updated = await updateBoard(userId, String(board._id), {
+      name: "New",
+    });
+    expect(updated.name).toBe("New");
+
+    expect(
+      await rejectionStatus(
+        updateBoard(newId(), String(board._id), { name: "Hijacked" }),
+      ),
+    ).toBe(404);
+  });
+
+  it("deletes an owned board and refuses non-owners", async () => {
+    const userId = newId();
+    const board = await createBoard(userId, { name: "Doomed" });
+
+    expect(
+      await rejectionStatus(deleteBoard(newId(), String(board._id))),
+    ).toBe(404);
+    expect(await Board.countDocuments()).toBe(1);
+
+    await deleteBoard(userId, String(board._id));
+    expect(await Board.countDocuments()).toBe(0);
+  });
+});
+
+describe("column CRUD", () => {
+  it("adds a lowercased column with a default color", async () => {
+    const userId = newId();
+    const board = await createBoard(userId, { name: "Board" });
+
+    const updated = await addColumn(userId, String(board._id), { name: "Todo" });
+
+    expect(updated.columns).toHaveLength(1);
+    expect(updated.columns[0].name).toBe("todo");
+    expect(updated.columns[0].color).toBe("default");
+  });
+
+  it("rejects a duplicate column name case-insensitively", async () => {
+    const userId = newId();
+    const board = await createBoard(userId, { name: "Board" });
+    await addColumn(userId, String(board._id), { name: "todo" });
+
+    expect(
+      await rejectionStatus(
+        addColumn(userId, String(board._id), { name: "TODO" }),
+      ),
+    ).toBe(409);
+  });
+
+  it("updates a column and blocks a name clash with another column", async () => {
+    const userId = newId();
+    let board = await createBoard(userId, { name: "Board" });
+    board = await addColumn(userId, String(board._id), { name: "todo" });
+    board = await addColumn(userId, String(board._id), { name: "doing" });
+
+    const doingId = String(
+      board.columns.find((c) => c.name === "doing")?._id,
+    );
+
+    const updated = await updateColumn(userId, String(board._id), doingId, {
+      name: "Done",
+      color: "#abc",
+    });
+    expect(updated.columns.find((c) => String(c._id) === doingId)?.name).toBe(
+      "done",
+    );
+
+    expect(
+      await rejectionStatus(
+        updateColumn(userId, String(board._id), doingId, {
+          name: "Todo",
+          color: "#abc",
+        }),
+      ),
+    ).toBe(409);
+  });
+
+  it("deletes a column and 404s a missing one", async () => {
+    const userId = newId();
+    let board = await createBoard(userId, { name: "Board" });
+    board = await addColumn(userId, String(board._id), { name: "todo" });
+    const columnId = String(board.columns[0]._id);
+
+    const updated = await deleteColumn(userId, String(board._id), columnId);
+    expect(updated.columns).toHaveLength(0);
+
+    expect(
+      await rejectionStatus(
+        deleteColumn(userId, String(board._id), newId()),
+      ),
+    ).toBe(404);
+  });
+});

--- a/lib/services/boards.test.ts
+++ b/lib/services/boards.test.ts
@@ -13,6 +13,7 @@ import {
   updateColumn,
   deleteColumn,
 } from "@/lib/services/boards";
+import { createTask } from "@/lib/services/tasks";
 
 const newId = () => new mongoose.Types.ObjectId().toString();
 
@@ -174,5 +175,68 @@ describe("column CRUD", () => {
         deleteColumn(userId, String(board._id), newId()),
       ),
     ).toBe(404);
+  });
+
+  it("updates only the color when no name is provided", async () => {
+    const userId = newId();
+    let board = await createBoard(userId, { name: "Board" });
+    board = await addColumn(userId, String(board._id), {
+      name: "todo",
+      color: "#111",
+    });
+    const columnId = String(board.columns[0]._id);
+
+    const updated = await updateColumn(userId, String(board._id), columnId, {
+      color: "#999",
+    });
+
+    expect(updated.columns[0].name).toBe("todo");
+    expect(updated.columns[0].color).toBe("#999");
+  });
+});
+
+describe("column changes cascade to tasks", () => {
+  it("renaming a column moves its tasks to the new name", async () => {
+    const userId = newId();
+    let board = await createBoard(userId, { name: "Board" });
+    board = await addColumn(userId, String(board._id), { name: "todo" });
+    const boardId = String(board._id);
+    board = await createTask(userId, boardId, {
+      title: "Task",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    const columnId = String(board.columns[0]._id);
+
+    const updated = await updateColumn(userId, boardId, columnId, {
+      name: "backlog",
+    });
+
+    expect(updated.columns[0].name).toBe("backlog");
+    expect(updated.tasks[0].status.name).toBe("backlog");
+  });
+
+  it("deleting a column deletes the tasks that live in it", async () => {
+    const userId = newId();
+    let board = await createBoard(userId, { name: "Board" });
+    board = await addColumn(userId, String(board._id), { name: "todo" });
+    board = await addColumn(userId, String(board._id), { name: "doing" });
+    const boardId = String(board._id);
+    board = await createTask(userId, boardId, {
+      title: "Keep",
+      status: { name: "doing" },
+      subtasks: [],
+    });
+    board = await createTask(userId, boardId, {
+      title: "Drop",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    const todoId = String(board.columns.find((c) => c.name === "todo")?._id);
+
+    const updated = await deleteColumn(userId, boardId, todoId);
+
+    expect(updated.columns.map((c) => c.name)).toEqual(["doing"]);
+    expect(updated.tasks.map((t) => t.title)).toEqual(["Keep"]);
   });
 });

--- a/lib/services/boards.ts
+++ b/lib/services/boards.ts
@@ -1,0 +1,120 @@
+import { isValidObjectId } from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { Board } from "@/lib/db/models/Board";
+import { conflict, notFound } from "./errors";
+import { findOwnedBoard, type BoardDocument } from "./access";
+
+export type { BoardDocument };
+
+export async function listBoards(userId: string): Promise<BoardDocument[]> {
+  await dbConnect();
+  return Board.find({ createdBy: userId }).sort({ createdAt: 1 });
+}
+
+export async function getBoard(
+  userId: string,
+  boardId: string,
+): Promise<BoardDocument> {
+  await dbConnect();
+  return findOwnedBoard(userId, boardId);
+}
+
+export async function createBoard(
+  userId: string,
+  input: { name: string; description?: string },
+): Promise<BoardDocument> {
+  await dbConnect();
+  return Board.create({
+    createdBy: userId,
+    name: input.name,
+    description: input.description,
+  });
+}
+
+export async function updateBoard(
+  userId: string,
+  boardId: string,
+  input: { name?: string; description?: string },
+): Promise<BoardDocument> {
+  await dbConnect();
+  const board = await findOwnedBoard(userId, boardId);
+  if (input.name !== undefined) board.name = input.name;
+  if (input.description !== undefined) board.description = input.description;
+  await board.save();
+  return board;
+}
+
+export async function deleteBoard(
+  userId: string,
+  boardId: string,
+): Promise<void> {
+  await dbConnect();
+  if (!isValidObjectId(boardId)) throw notFound("Board not found");
+  const board = await Board.findOneAndDelete({
+    _id: boardId,
+    createdBy: userId,
+  });
+  if (!board) throw notFound("Board not found");
+}
+
+// Column names are stored lowercase and must be unique within a board.
+export async function addColumn(
+  userId: string,
+  boardId: string,
+  input: { name: string; color?: string },
+): Promise<BoardDocument> {
+  await dbConnect();
+  const board = await findOwnedBoard(userId, boardId);
+
+  const name = input.name.toLowerCase();
+  if (board.columns.some((column) => column.name.toLowerCase() === name)) {
+    throw conflict(`Column "${input.name}" already exists`);
+  }
+
+  board.columns.push({ name, color: input.color || "default" });
+  await board.save();
+  return board;
+}
+
+export async function updateColumn(
+  userId: string,
+  boardId: string,
+  columnId: string,
+  input: { name: string; color: string },
+): Promise<BoardDocument> {
+  await dbConnect();
+  if (!isValidObjectId(columnId)) throw notFound("Column not found");
+  const board = await findOwnedBoard(userId, boardId);
+
+  const column = board.columns.id(columnId);
+  if (!column) throw notFound("Column not found");
+
+  const name = input.name.toLowerCase();
+  const clashes = board.columns.some(
+    (other) =>
+      String(other._id) !== String(column._id) &&
+      other.name.toLowerCase() === name,
+  );
+  if (clashes) throw conflict(`Column "${input.name}" already exists`);
+
+  column.name = name;
+  column.color = input.color;
+  await board.save();
+  return board;
+}
+
+export async function deleteColumn(
+  userId: string,
+  boardId: string,
+  columnId: string,
+): Promise<BoardDocument> {
+  await dbConnect();
+  if (!isValidObjectId(columnId)) throw notFound("Column not found");
+  const board = await findOwnedBoard(userId, boardId);
+
+  if (!board.columns.id(columnId)) throw notFound("Column not found");
+
+  board.columns.pull(columnId);
+  await board.save();
+  return board;
+}

--- a/lib/services/boards.ts
+++ b/lib/services/boards.ts
@@ -80,7 +80,7 @@ export async function updateColumn(
   userId: string,
   boardId: string,
   columnId: string,
-  input: { name: string; color: string },
+  input: { name?: string; color?: string },
 ): Promise<BoardDocument> {
   await dbConnect();
   if (!isValidObjectId(columnId)) throw notFound("Column not found");
@@ -89,16 +89,30 @@ export async function updateColumn(
   const column = board.columns.id(columnId);
   if (!column) throw notFound("Column not found");
 
-  const name = input.name.toLowerCase();
-  const clashes = board.columns.some(
-    (other) =>
-      String(other._id) !== String(column._id) &&
-      other.name.toLowerCase() === name,
-  );
-  if (clashes) throw conflict(`Column "${input.name}" already exists`);
+  if (input.name !== undefined) {
+    const name = input.name.toLowerCase();
+    const clashes = board.columns.some(
+      (other) =>
+        String(other._id) !== String(column._id) &&
+        other.name.toLowerCase() === name,
+    );
+    if (clashes) throw conflict(`Column "${input.name}" already exists`);
 
-  column.name = name;
-  column.color = input.color;
+    // Tasks snapshot their column name, so a rename has to follow through to
+    // every task in this column or those tasks would point at a stale status.
+    const previousName = column.name;
+    if (previousName !== name) {
+      for (const task of board.tasks) {
+        if (task.status.name === previousName) {
+          task.status = { name, color: task.status.color };
+        }
+      }
+    }
+    column.name = name;
+  }
+
+  if (input.color !== undefined) column.color = input.color;
+
   await board.save();
   return board;
 }
@@ -112,7 +126,15 @@ export async function deleteColumn(
   if (!isValidObjectId(columnId)) throw notFound("Column not found");
   const board = await findOwnedBoard(userId, boardId);
 
-  if (!board.columns.id(columnId)) throw notFound("Column not found");
+  const column = board.columns.id(columnId);
+  if (!column) throw notFound("Column not found");
+
+  // A task lives in exactly one column; deleting the column deletes its tasks
+  // rather than leaving them with a status that no longer exists.
+  const orphanedTaskIds = board.tasks
+    .filter((task) => task.status.name === column.name)
+    .map((task) => task._id);
+  for (const taskId of orphanedTaskIds) board.tasks.pull(taskId);
 
   board.columns.pull(columnId);
   await board.save();

--- a/lib/services/errors.ts
+++ b/lib/services/errors.ts
@@ -1,0 +1,16 @@
+// Domain errors carry the HTTP status the route handler should return. The
+// route wrapper (lib/api/route.ts) maps these to responses, keeping the
+// services free of any HTTP concerns.
+export class ServiceError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ServiceError";
+  }
+}
+
+export const badRequest = (message: string) => new ServiceError(400, message);
+export const notFound = (message: string) => new ServiceError(404, message);
+export const conflict = (message: string) => new ServiceError(409, message);

--- a/lib/services/tasks.test.ts
+++ b/lib/services/tasks.test.ts
@@ -71,6 +71,19 @@ describe("createTask", () => {
     expect(task.subtasks.every((s) => s.completed === false)).toBe(true);
   });
 
+  it("stores the column's canonical name regardless of input casing", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+
+    const board = await createTask(userId, boardId, {
+      title: "Cased",
+      status: { name: "TODO" },
+      subtasks: [],
+    });
+
+    expect(lastTask(board).status.name).toBe("todo");
+  });
+
   it("rejects a status that is not one of the board's columns", async () => {
     const userId = newId();
     const { boardId } = await boardWithColumns(userId);

--- a/lib/services/tasks.test.ts
+++ b/lib/services/tasks.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import { Board } from "@/lib/db/models/Board";
+import { ServiceError } from "@/lib/services/errors";
+import { createBoard, addColumn } from "@/lib/services/boards";
+import type { BoardDocument } from "@/lib/services/boards";
+import {
+  createTask,
+  updateTask,
+  updateSubtask,
+  deleteTask,
+} from "@/lib/services/tasks";
+
+const newId = () => new mongoose.Types.ObjectId().toString();
+
+async function rejectionStatus(promise: Promise<unknown>): Promise<number> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof ServiceError) return error.status;
+    throw error;
+  }
+  throw new Error("Expected the call to reject, but it resolved");
+}
+
+// A board with two columns ("todo", "doing") for the requesting user.
+async function boardWithColumns(
+  userId: string,
+): Promise<{ board: BoardDocument; boardId: string }> {
+  let board = await createBoard(userId, { name: "Board" });
+  board = await addColumn(userId, String(board._id), { name: "todo" });
+  board = await addColumn(userId, String(board._id), { name: "doing" });
+  return { board, boardId: String(board._id) };
+}
+
+const lastTask = (board: BoardDocument) => board.tasks[board.tasks.length - 1];
+
+beforeAll(async () => {
+  await dbConnect();
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  await Board.deleteMany({});
+});
+
+describe("createTask", () => {
+  it("adds a task with subtasks derived from titles", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+
+    const board = await createTask(userId, boardId, {
+      title: "Ship it",
+      status: { name: "todo" },
+      description: "soon",
+      subtasks: ["write tests", "open PR"],
+    });
+
+    const task = lastTask(board);
+    expect(task.title).toBe("Ship it");
+    expect(task.subtasks).toHaveLength(2);
+    expect(task.subtasks.map((s) => s.title)).toEqual([
+      "write tests",
+      "open PR",
+    ]);
+    expect(task.subtasks.every((s) => s.completed === false)).toBe(true);
+  });
+
+  it("rejects a status that is not one of the board's columns", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+
+    expect(
+      await rejectionStatus(
+        createTask(userId, boardId, {
+          title: "Orphan",
+          status: { name: "nope" },
+          subtasks: [],
+        }),
+      ),
+    ).toBe(400);
+  });
+
+  it("404s when the board does not belong to the user", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+
+    expect(
+      await rejectionStatus(
+        createTask(newId(), boardId, {
+          title: "Hijack",
+          status: { name: "todo" },
+          subtasks: [],
+        }),
+      ),
+    ).toBe(404);
+  });
+});
+
+describe("updateTask", () => {
+  it("moves a task to another column and replaces its subtasks", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    let board = await createTask(userId, boardId, {
+      title: "Task",
+      status: { name: "todo" },
+      subtasks: ["a"],
+    });
+    const taskId = String(lastTask(board)._id);
+
+    board = await updateTask(userId, boardId, taskId, {
+      status: { name: "doing" },
+      subtasks: ["x", "y"],
+    });
+
+    const task = board.tasks.id(taskId)!;
+    expect(task.status.name).toBe("doing");
+    expect(task.subtasks.map((s) => s.title)).toEqual(["x", "y"]);
+  });
+
+  it("rejects a status outside the board's columns", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const board = await createTask(userId, boardId, {
+      title: "Task",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    const taskId = String(lastTask(board)._id);
+
+    expect(
+      await rejectionStatus(
+        updateTask(userId, boardId, taskId, { status: { name: "ghost" } }),
+      ),
+    ).toBe(400);
+  });
+
+  it("404s a missing task", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+
+    expect(
+      await rejectionStatus(
+        updateTask(userId, boardId, newId(), { title: "x" }),
+      ),
+    ).toBe(404);
+  });
+});
+
+describe("updateSubtask", () => {
+  it("toggles a subtask's completed state", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    let board = await createTask(userId, boardId, {
+      title: "Task",
+      status: { name: "todo" },
+      subtasks: ["one"],
+    });
+    const taskId = String(lastTask(board)._id);
+    const subtaskId = String(lastTask(board).subtasks[0]._id);
+
+    board = await updateSubtask(userId, boardId, taskId, subtaskId, {
+      completed: true,
+    });
+
+    expect(board.tasks.id(taskId)!.subtasks.id(subtaskId)!.completed).toBe(true);
+  });
+
+  it("404s a missing subtask", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const board = await createTask(userId, boardId, {
+      title: "Task",
+      status: { name: "todo" },
+      subtasks: ["one"],
+    });
+    const taskId = String(lastTask(board)._id);
+
+    expect(
+      await rejectionStatus(
+        updateSubtask(userId, boardId, taskId, newId(), { completed: true }),
+      ),
+    ).toBe(404);
+  });
+});
+
+describe("deleteTask", () => {
+  it("removes a task and 404s a missing one", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const board = await createTask(userId, boardId, {
+      title: "Task",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    const taskId = String(lastTask(board)._id);
+
+    const updated = await deleteTask(userId, boardId, taskId);
+    expect(updated.tasks).toHaveLength(0);
+
+    expect(
+      await rejectionStatus(deleteTask(userId, boardId, newId())),
+    ).toBe(404);
+  });
+});

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -5,11 +5,15 @@ import { badRequest, notFound } from "./errors";
 import { findOwnedBoard, type BoardDocument } from "./access";
 
 // A task's status must name one of the board's columns (case-insensitive).
-function assertStatusIsAColumn(board: BoardDocument, status: IStatus): void {
-  const exists = board.columns.some(
-    (column) => column.name.toLowerCase() === status.name.toLowerCase(),
+// Returns the column's canonical (stored) name so the snapshot on the task
+// always matches its column exactly, which keeps column rename/delete and any
+// status comparisons consistent.
+function resolveStatusName(board: BoardDocument, status: IStatus): string {
+  const column = board.columns.find(
+    (col) => col.name.toLowerCase() === status.name.toLowerCase(),
   );
-  if (!exists) throw badRequest(`Column "${status.name}" does not exist`);
+  if (!column) throw badRequest(`Column "${status.name}" does not exist`);
+  return column.name;
 }
 
 export async function createTask(
@@ -24,11 +28,11 @@ export async function createTask(
 ): Promise<BoardDocument> {
   await dbConnect();
   const board = await findOwnedBoard(userId, boardId);
-  assertStatusIsAColumn(board, input.status);
+  const statusName = resolveStatusName(board, input.status);
 
   const task = board.tasks.create({
     title: input.title,
-    status: input.status,
+    status: { name: statusName, color: input.status.color },
     description: input.description,
     subtasks: input.subtasks.map((title) => ({ title, completed: false })),
   });
@@ -56,11 +60,15 @@ export async function updateTask(
   const task = board.tasks.id(taskId);
   if (!task) throw notFound("Task not found");
 
-  if (input.status) assertStatusIsAColumn(board, input.status);
+  // Resolve up front so an invalid status rejects before any mutation.
+  const statusName =
+    input.status !== undefined ? resolveStatusName(board, input.status) : null;
 
   if (input.title !== undefined) task.title = input.title;
   if (input.description !== undefined) task.description = input.description;
-  if (input.status !== undefined) task.status = input.status;
+  if (input.status !== undefined && statusName !== null) {
+    task.status = { name: statusName, color: input.status.color };
+  }
 
   // Replacing the subtask list resets completion state, matching the task-edit
   // modal where subtasks are entered as plain titles.

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -1,0 +1,117 @@
+import { isValidObjectId } from "mongoose";
+import { dbConnect } from "@/lib/db/mongoose";
+import type { IStatus } from "@/lib/db/models/Board";
+import { badRequest, notFound } from "./errors";
+import { findOwnedBoard, type BoardDocument } from "./access";
+
+// A task's status must name one of the board's columns (case-insensitive).
+function assertStatusIsAColumn(board: BoardDocument, status: IStatus): void {
+  const exists = board.columns.some(
+    (column) => column.name.toLowerCase() === status.name.toLowerCase(),
+  );
+  if (!exists) throw badRequest(`Column "${status.name}" does not exist`);
+}
+
+export async function createTask(
+  userId: string,
+  boardId: string,
+  input: {
+    title: string;
+    status: IStatus;
+    description?: string;
+    subtasks: string[];
+  },
+): Promise<BoardDocument> {
+  await dbConnect();
+  const board = await findOwnedBoard(userId, boardId);
+  assertStatusIsAColumn(board, input.status);
+
+  const task = board.tasks.create({
+    title: input.title,
+    status: input.status,
+    description: input.description,
+    subtasks: input.subtasks.map((title) => ({ title, completed: false })),
+  });
+  board.tasks.push(task);
+
+  await board.save();
+  return board;
+}
+
+export async function updateTask(
+  userId: string,
+  boardId: string,
+  taskId: string,
+  input: {
+    title?: string;
+    description?: string;
+    status?: IStatus;
+    subtasks?: string[];
+  },
+): Promise<BoardDocument> {
+  await dbConnect();
+  if (!isValidObjectId(taskId)) throw notFound("Task not found");
+  const board = await findOwnedBoard(userId, boardId);
+
+  const task = board.tasks.id(taskId);
+  if (!task) throw notFound("Task not found");
+
+  if (input.status) assertStatusIsAColumn(board, input.status);
+
+  if (input.title !== undefined) task.title = input.title;
+  if (input.description !== undefined) task.description = input.description;
+  if (input.status !== undefined) task.status = input.status;
+
+  // Replacing the subtask list resets completion state, matching the task-edit
+  // modal where subtasks are entered as plain titles.
+  if (input.subtasks !== undefined) {
+    task.subtasks.splice(0, task.subtasks.length);
+    for (const title of input.subtasks) {
+      task.subtasks.push({ title, completed: false });
+    }
+  }
+
+  await board.save();
+  return board;
+}
+
+export async function updateSubtask(
+  userId: string,
+  boardId: string,
+  taskId: string,
+  subtaskId: string,
+  input: { title?: string; completed?: boolean },
+): Promise<BoardDocument> {
+  await dbConnect();
+  if (!isValidObjectId(taskId)) throw notFound("Task not found");
+  if (!isValidObjectId(subtaskId)) throw notFound("Subtask not found");
+  const board = await findOwnedBoard(userId, boardId);
+
+  const task = board.tasks.id(taskId);
+  if (!task) throw notFound("Task not found");
+
+  const subtask = task.subtasks.id(subtaskId);
+  if (!subtask) throw notFound("Subtask not found");
+
+  if (input.title !== undefined) subtask.title = input.title;
+  if (input.completed !== undefined) subtask.completed = input.completed;
+
+  await board.save();
+  return board;
+}
+
+export async function deleteTask(
+  userId: string,
+  boardId: string,
+  taskId: string,
+): Promise<BoardDocument> {
+  await dbConnect();
+  if (!isValidObjectId(taskId)) throw notFound("Task not found");
+  const board = await findOwnedBoard(userId, boardId);
+
+  if (!board.tasks.id(taskId)) throw notFound("Task not found");
+
+  board.tasks.pull(taskId);
+  await board.save();
+  return board;
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -20,20 +20,63 @@ export const loginSchema = z.object({
 
 export const boardSchema = z.object({
   name: z.string().min(1).max(25),
-  description: z.string().max(100).optional(),
+  description: z.string().min(3).max(100).optional(),
 });
+
+// Boards can be renamed or re-described; require at least one field to change.
+export const boardUpdateSchema = z
+  .object({
+    name: z.string().min(1).max(25).optional(),
+    description: z.string().min(3).max(100).optional(),
+  })
+  .refine((data) => data.name !== undefined || data.description !== undefined, {
+    message: "Provide a name or description to update",
+  });
 
 export const columnSchema = z.object({
   name: z.string().min(3, "Column name must be more than 2 characters"),
   color: z.string().optional(),
 });
 
+export const columnUpdateSchema = z.object({
+  name: z.string().min(3, "Column name must be more than 2 characters"),
+  color: z.string().min(1, "A color is required"),
+});
+
+const statusSchema = z.object({
+  name: z.string().min(1),
+  color: z.string().optional(),
+});
+
 export const taskSchema = z.object({
   title: z.string().min(1),
   description: z.string().optional(),
-  status: z.object({ name: z.string(), color: z.string().optional() }),
-  subtasks: z.array(z.string()).default([]),
+  status: statusSchema,
+  subtasks: z.array(z.string().min(1)).default([]),
 });
+
+// Editing a task can replace its subtask list (by title); completion state is
+// managed through the subtask endpoint. Require at least one field to change.
+export const taskUpdateSchema = z
+  .object({
+    title: z.string().min(1).optional(),
+    description: z.string().optional(),
+    status: statusSchema.optional(),
+    subtasks: z.array(z.string().min(1)).optional(),
+  })
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
+    message: "Provide at least one field to update",
+  });
+
+export const subtaskUpdateSchema = z
+  .object({
+    title: z.string().min(1).optional(),
+    completed: z.boolean().optional(),
+  })
+  .refine(
+    (data) => data.title !== undefined || data.completed !== undefined,
+    { message: "Provide a title or completed state to update" },
+  );
 
 export const passwordResetRequestSchema = z.object({
   email: z.email(),

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -38,10 +38,17 @@ export const columnSchema = z.object({
   color: z.string().optional(),
 });
 
-export const columnUpdateSchema = z.object({
-  name: z.string().min(3, "Column name must be more than 2 characters"),
-  color: z.string().min(1, "A color is required"),
-});
+export const columnUpdateSchema = z
+  .object({
+    name: z
+      .string()
+      .min(3, "Column name must be more than 2 characters")
+      .optional(),
+    color: z.string().min(1, "A color is required").optional(),
+  })
+  .refine((data) => data.name !== undefined || data.color !== undefined, {
+    message: "Provide a name or color to update",
+  });
 
 const statusSchema = z.object({
   name: z.string().min(1),


### PR DESCRIPTION
## Problem

The rebuild has auth and a data layer but no way to read or change boards. The kanban core, creating boards, columns, tasks, and subtasks, lived in the v1 Express services and needs to be rebuilt as Next.js Route Handlers before any UI can exist.

## Approach

A framework-free service layer with thin Route Handlers on top (ADR 0002, parity first).

- **Service layer (`lib/services/`).** Ports the v1 board and task logic as plain functions: ownership-scoped board CRUD, column add/update/delete, and task/subtask mutations. Preserves v1 rules (a task's status must name a board column; column names are lowercased and unique). Services know nothing about HTTP, they throw domain errors carrying a status.
- **Nested REST surface.** `/api/boards`, `/api/boards/[boardId]`, `.../columns[/columnId]`, `.../tasks[/taskId][/subtasks/subtaskId]`. Tasks are nested under their board, so every task mutation is ownership-scoped by the board lookup, replacing v1's global `tasks._id` queries.
- **Shared `authed` wrapper.** One place enforces the session (401), resolves the awaited route params, and maps `ServiceError` / `ZodError` / malformed JSON to responses. Handlers stay three lines each.
- **Mongoose 9 port.** `subdoc.remove()` was removed; subdocuments are deleted with `DocumentArray.pull`. The Board model's subdocument arrays are typed as `DocumentArray` so `.id()` / `.pull()` are available, with `_id` optional on the interfaces so plain objects can be pushed.
- **Improvement over v1.** Added board rename and delete, which the old API never exposed.

## Tradeoffs / alternatives considered

- **Load-mutate-save vs. positional array updates.** Loading the board, mutating subdocuments, and saving is simpler and matches v1; targeted `$` positional updates would cut writes but are error-prone for nested `tasks.subtasks`. At a kanban board's scale, clarity wins. Revisit if contention ever shows up.
- **Service layer vs. logic in the handlers.** The extra layer keeps all domain rules unit-testable without HTTP or Auth.js, and lets the handlers be uniform. Worth the indirection.
- **Editing a task replaces its subtasks (by title) and resets completion.** This matches the v1 task-edit modal, where subtasks are plain text inputs; per-subtask completion is handled by the subtask endpoint. Documented so it is a choice, not a surprise.
- **Return the whole board on every mutation.** Heavier than returning the changed entity, but it lets the client refresh board state from one response; boards are small. The UI slice can narrow this later.
- **Invalid object ids map to 404, not 400.** Avoids leaking existence and keeps malformed ids from reaching Mongoose as cast errors.
- **Did not refactor the auth routes onto the new wrapper.** They predate it and do not need the auth gate; leaving them avoids churning a merged slice.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` all clean (7 board/task routes registered).
- `npm test`: 44 passing. New tests cover the board service (ownership scoping, lowercased/unique columns, malformed/foreign ids), the task service (status validation, subtask creation and replacement, completion toggles, deletion), and the route wrapper (401, params passthrough, error mapping).
- No UI yet, so no screenshots; the board UI that consumes these lands next.

https://claude.ai/code/session_01R1FckjFUQVsxm5z5UjmU6U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full board management: create, view, rename, and delete boards.
  * Added column, task, and subtask creation, editing, and deletion within boards.
  * Improved board and task rules so names and task details are validated more consistently.

* **Bug Fixes**
  * Tightened ownership checks so users only see and change their own boards.
  * Added clearer handling for invalid or missing data, including duplicate column names and invalid task statuses.

* **Tests**
  * Expanded automated integration coverage for board, column, task, and subtask workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->