### PR TITLE
docs(changelog): note board CRUD and drag-and-drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Board interactivity: create/edit/delete dialogs for boards, columns (with a color
+  picker), and tasks (title, description, status, and a dynamic subtask list); an
+  interactive task modal with subtask toggles and status changes; and dnd-kit drag of tasks
+  between columns. Mutations are optimistic with toast feedback (sonner) and roll back on
+  failure; the optimistic paths keep their own change rather than replacing the whole board
+  on success, so concurrent edits are not clobbered. Board/column/task/subtask mutation
+  Route Handlers now return the board as a serialized DTO, and a new `BoardWorkspace` client
+  component owns active-board state and routes every dialog. Drag is a pointer enhancement;
+  the keyboard-accessible way to move a task is the status select in the task modal. Covered
+  by Vitest tests and verified end to end.
 - Board view: a responsive boards workspace with a board-list sidebar (a slide-over drawer
   on small screens), columns rendered from each board's schema, task cards showing subtask
   progress, and a read-only task modal. The sidebar and task modal share one accessible


### PR DESCRIPTION
## Problem

The board interactivity slice (PR #14) merged without its `CHANGELOG.md` entry; the
per-slice convention under `[Unreleased]` was missed in that PR.

## Approach

Add an `[Unreleased] > Added` entry (newest-first, matching the existing style) describing
board/column/task CRUD dialogs, the interactive task modal, dnd-kit drag, optimistic updates
with toasts, and the DTO-returning mutation routes.

## Tradeoffs / alternatives considered

Ideally this line ships inside the feature PR. Since #14 already merged, a focused docs PR
keeps `develop` honest and the changelog accurate rather than folding it silently into an
unrelated future slice.

## Testing

Docs only — no code change. `CHANGELOG.md` renders as valid Keep a Changelog markdown.

Assisted-by: Claude (Opus 4.8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded board workspace support with dialogs for creating and editing boards, columns, tasks, and subtasks, including color selection and dynamic subtask lists.
  * Added an interactive task view with subtask toggles, status changes, drag-and-drop task movement, and a keyboard-accessible status selector.
  * Improved reliability with optimistic updates, toast feedback, and safer handling of concurrent edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->