### PR TITLE
feat(board): accessibility and mobile pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Accessibility and mobile pass over the board. Tasks can now be moved by keyboard and screen
+  reader through each card's actions menu ("Move to `<column>`"), not only by pointer drag, and
+  drag gains screen-reader live-region announcements. Stacked overlays (a menu inside a modal)
+  now share one topmost-overlay registry, so `Escape` dismisses only the frontmost layer instead
+  of relying on an ad-hoc capture-phase listener. Touch drag is press-and-hold, so a tap still
+  opens a task and a swipe still scrolls the board; the columns row is a labelled, keyboard-
+  focusable region; and a `prefers-reduced-motion` preference quiets transitions, the sonner
+  toasts, and the drag animation. Adds an automated accessibility gate (vitest-axe) over the task
+  card, menu, and task modal.
 - Began the v2 rebuild: migrating from a Vue/Quasar client plus a standalone Express API
   to a single Next.js 16 full-stack application (see `docs/adr/0002`). Established
   architecture decision records and contribution conventions.

--- a/app/globals.css
+++ b/app/globals.css
@@ -27,3 +27,17 @@ body {
 ::selection {
   background: color-mix(in srgb, var(--color-accent) 40%, transparent);
 }
+
+/* Honor the OS "reduce motion" setting everywhere: neutralize transitions and
+   animations (Tailwind transitions, the sonner toasts, the drag drop tween)
+   rather than chasing each call site. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/components/board/BoardWorkspace.tsx
+++ b/components/board/BoardWorkspace.tsx
@@ -5,17 +5,21 @@ import { useRouter } from "next/navigation";
 import {
   DndContext,
   DragOverlay,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   pointerWithin,
   useSensor,
   useSensors,
+  type Announcements,
   type DragEndEvent,
   type DragStartEvent,
+  type ScreenReaderInstructions,
 } from "@dnd-kit/core";
 import { toast } from "sonner";
 import type { BoardDTO, ColumnDTO, TaskDTO } from "@/lib/dto";
 import { apiFetch, errorMessage } from "@/lib/api/client";
 import { withMovedTask, withToggledSubtask } from "@/lib/board/optimistic";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { Button } from "@/components/ui/Button";
 import { Menu, MenuItem } from "@/components/ui/Menu";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -248,10 +252,50 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
 
   // --- Drag and drop ----------------------------------------------------
 
+  const reducedMotion = usePrefersReducedMotion();
+
   const sensors = useSensors(
-    // A small activation distance lets a plain click still open the task.
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    // Mouse: a small activation distance lets a plain click still open the task.
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    // Touch: press-and-hold to drag, so a tap still opens the task and a swipe
+    // still scrolls the horizontal board instead of picking up a card.
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 8 },
+    }),
   );
+
+  const taskTitle = (id: string) =>
+    board.tasks.find((item) => item.id === id)?.title ?? "task";
+  const columnFromOverId = (overId: string) => overId.replace(/^col:/, "");
+
+  // Live-region messages so assistive tech follows a pointer drag; the discrete
+  // keyboard/screen-reader move path is each card's "Move to" menu.
+  const announcements: Announcements = {
+    onDragStart({ active }) {
+      return `Picked up task ${taskTitle(String(active.id))}.`;
+    },
+    onDragOver({ active, over }) {
+      const name = taskTitle(String(active.id));
+      return over
+        ? `Task ${name} is over the ${columnFromOverId(String(over.id))} column.`
+        : `Task ${name} is not over a column.`;
+    },
+    onDragEnd({ active, over }) {
+      const name = taskTitle(String(active.id));
+      return over
+        ? `Task ${name} was moved to the ${columnFromOverId(String(over.id))} column.`
+        : `Task ${name} was dropped without moving.`;
+    },
+    onDragCancel({ active }) {
+      return `Moving task ${taskTitle(String(active.id))} was cancelled.`;
+    },
+  };
+
+  const screenReaderInstructions: ScreenReaderInstructions = {
+    draggable:
+      "Drag a task with a pointer to move it between columns. Keyboard and " +
+      "screen-reader users can move a task from its actions menu.",
+  };
 
   function onDragStart(event: DragStartEvent) {
     const task = board.tasks.find((item) => item.id === event.active.id);
@@ -262,8 +306,7 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
     setActiveDragTask(null);
     const { active, over } = event;
     if (!over) return;
-    const toColumnName = String(over.id).replace(/^col:/, "");
-    void moveTask(String(active.id), toColumnName);
+    void moveTask(String(active.id), columnFromOverId(String(over.id)));
   }
 
   // --- Render -----------------------------------------------------------
@@ -301,18 +344,34 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
         <DndContext
           sensors={sensors}
           collisionDetection={pointerWithin}
+          accessibility={{ announcements, screenReaderInstructions }}
           onDragStart={onDragStart}
           onDragEnd={onDragEnd}
           onDragCancel={() => setActiveDragTask(null)}
         >
-          <div className="flex min-h-0 flex-1 gap-6 overflow-x-auto px-4 py-6 sm:px-6">
+          <div
+            role="region"
+            aria-label="Board columns"
+            tabIndex={0}
+            className="flex min-h-0 flex-1 gap-6 overflow-x-auto px-4 py-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--color-accent)] sm:px-6"
+          >
             {columns.map((column, index) => (
               <Column
                 key={column.id}
                 column={column}
                 index={index}
                 tasks={tasksFor(column.name)}
+                columns={columns}
                 onOpenTask={(task) => setSelectedTaskId(task.id)}
+                onMoveTask={(task, toColumnName) =>
+                  moveTask(task.id, toColumnName)
+                }
+                onEditTask={(task) =>
+                  setDialog({ type: "edit-task", taskId: task.id })
+                }
+                onDeleteTask={(task) =>
+                  setDialog({ type: "delete-task", taskId: task.id })
+                }
                 onEditColumn={(col) =>
                   setDialog({ type: "edit-column", columnId: col.id })
                 }
@@ -330,9 +389,9 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
             </button>
           </div>
 
-          <DragOverlay>
+          <DragOverlay dropAnimation={reducedMotion ? null : undefined}>
             {activeDragTask ? (
-              <div className="w-72 rotate-2">
+              <div className={reducedMotion ? "w-72" : "w-72 rotate-2"}>
                 <TaskCard task={activeDragTask} onOpen={() => {}} />
               </div>
             ) : null}

--- a/components/board/Column.tsx
+++ b/components/board/Column.tsx
@@ -10,7 +10,12 @@ interface ColumnProps {
   column: ColumnDTO;
   index: number;
   tasks: TaskDTO[];
+  // All board columns, so each card's "Move to" menu can list the others.
+  columns: ColumnDTO[];
   onOpenTask: (task: TaskDTO) => void;
+  onMoveTask: (task: TaskDTO, toColumnName: string) => void;
+  onEditTask: (task: TaskDTO) => void;
+  onDeleteTask: (task: TaskDTO) => void;
   onEditColumn: (column: ColumnDTO) => void;
   onDeleteColumn: (column: ColumnDTO) => void;
 }
@@ -19,7 +24,11 @@ export function Column({
   column,
   index,
   tasks,
+  columns,
   onOpenTask,
+  onMoveTask,
+  onEditTask,
+  onDeleteTask,
   onEditColumn,
   onDeleteColumn,
 }: ColumnProps) {
@@ -66,7 +75,15 @@ export function Column({
           </p>
         ) : (
           tasks.map((task) => (
-            <DraggableTaskCard key={task.id} task={task} onOpen={onOpenTask} />
+            <DraggableTaskCard
+              key={task.id}
+              task={task}
+              columns={columns}
+              onOpen={onOpenTask}
+              onMove={onMoveTask}
+              onEdit={onEditTask}
+              onDelete={onDeleteTask}
+            />
           ))
         )}
       </div>

--- a/components/board/DraggableTaskCard.tsx
+++ b/components/board/DraggableTaskCard.tsx
@@ -1,19 +1,28 @@
 "use client";
 
 import { useDraggable } from "@dnd-kit/core";
-import type { TaskDTO } from "@/lib/dto";
+import type { ColumnDTO, TaskDTO } from "@/lib/dto";
 import { TaskCard } from "./TaskCard";
 
 // Wraps a task card with pointer-drag wiring. Only `listeners` (pointer events)
 // are spread onto the card, not dnd-kit's keyboard `attributes`: the card stays
-// a plain button whose keyboard path is "open the task, change its status",
-// while pointer users can additionally drag it between columns.
+// a plain button whose keyboard/screen-reader move path is the card's "..."
+// actions menu ("Move to <column>"), while pointer users can additionally drag
+// it between columns.
 export function DraggableTaskCard({
   task,
   onOpen,
+  columns,
+  onMove,
+  onEdit,
+  onDelete,
 }: {
   task: TaskDTO;
   onOpen: (task: TaskDTO) => void;
+  columns: ColumnDTO[];
+  onMove: (task: TaskDTO, toColumnName: string) => void;
+  onEdit: (task: TaskDTO) => void;
+  onDelete: (task: TaskDTO) => void;
 }) {
   const { setNodeRef, listeners, isDragging } = useDraggable({
     id: task.id,
@@ -27,6 +36,10 @@ export function DraggableTaskCard({
       dragRef={setNodeRef}
       dragListeners={listeners}
       dragging={isDragging}
+      columns={columns}
+      onMove={onMove}
+      onEdit={onEdit}
+      onDelete={onDelete}
     />
   );
 }

--- a/components/board/TaskCard.test.tsx
+++ b/components/board/TaskCard.test.tsx
@@ -3,7 +3,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TaskCard } from "./TaskCard";
-import type { TaskDTO } from "@/lib/dto";
+import type { ColumnDTO, TaskDTO } from "@/lib/dto";
+
+const columns: ColumnDTO[] = [
+  { id: "c1", name: "todo", color: "" },
+  { id: "c2", name: "doing", color: "" },
+  { id: "c3", name: "done", color: "" },
+];
 
 function makeTask(overrides: Partial<TaskDTO> = {}): TaskDTO {
   return {
@@ -42,8 +48,58 @@ describe("TaskCard", () => {
     const task = makeTask();
     render(<TaskCard task={task} onOpen={onOpen} />);
 
-    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(
+      screen.getByRole("button", { name: /open task: build the board view/i }),
+    );
 
     expect(onOpen).toHaveBeenCalledWith(task);
+  });
+
+  it("has no actions menu when no action handlers are provided", () => {
+    render(<TaskCard task={makeTask()} onOpen={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /actions for/i })).toBeNull();
+  });
+
+  it("moves, edits, and deletes through the actions menu", async () => {
+    const onMove = vi.fn();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const task = makeTask();
+    render(
+      <TaskCard
+        task={task}
+        onOpen={vi.fn()}
+        columns={columns}
+        onMove={onMove}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+
+    const openMenu = () =>
+      userEvent.click(
+        screen.getByRole("button", { name: /actions for build the board view/i }),
+      );
+
+    await openMenu();
+    // The current column ("todo") is not offered as a move target.
+    expect(
+      screen.queryByRole("menuitem", { name: /move to todo/i }),
+    ).toBeNull();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /move to doing/i }),
+    );
+    expect(onMove).toHaveBeenCalledWith(task, "doing");
+
+    await openMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: /edit task/i }));
+    expect(onEdit).toHaveBeenCalledWith(task);
+
+    await openMenu();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /delete task/i }),
+    );
+    expect(onDelete).toHaveBeenCalledWith(task);
   });
 });

--- a/components/board/TaskCard.tsx
+++ b/components/board/TaskCard.tsx
@@ -1,5 +1,6 @@
 import type { DraggableSyntheticListeners } from "@dnd-kit/core";
-import type { TaskDTO } from "@/lib/dto";
+import type { ColumnDTO, TaskDTO } from "@/lib/dto";
+import { Menu, MenuItem } from "@/components/ui/Menu";
 
 interface TaskCardProps {
   task: TaskDTO;
@@ -9,6 +10,13 @@ interface TaskCardProps {
   dragRef?: (element: HTMLElement | null) => void;
   dragListeners?: DraggableSyntheticListeners;
   dragging?: boolean;
+  // Optional on-card actions. When provided, the card grows a "..." menu whose
+  // "Move to" items are the keyboard/screen-reader path to move a task (pointer
+  // users can also drag). Omitted for the drag overlay and static/test renders.
+  columns?: ColumnDTO[];
+  onMove?: (task: TaskDTO, toColumnName: string) => void;
+  onEdit?: (task: TaskDTO) => void;
+  onDelete?: (task: TaskDTO) => void;
 }
 
 export function TaskCard({
@@ -17,28 +25,67 @@ export function TaskCard({
   dragRef,
   dragListeners,
   dragging = false,
+  columns,
+  onMove,
+  onEdit,
+  onDelete,
 }: TaskCardProps) {
   const total = task.subtasks.length;
   const done = task.subtasks.filter((subtask) => subtask.completed).length;
+  const hasActions = Boolean(onMove || onEdit || onDelete);
+  // Every column except the one the task already sits in.
+  const moveTargets =
+    columns?.filter((column) => column.name !== task.status.name) ?? [];
 
   return (
-    <button
-      ref={dragRef}
-      type="button"
-      onClick={() => onOpen(task)}
-      {...dragListeners}
-      className={`group flex w-full touch-none flex-col gap-2 rounded-lg bg-[var(--color-surface)] px-4 py-4 text-left shadow-sm transition-colors hover:bg-[var(--color-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
-        dragging ? "opacity-40" : ""
-      }`}
-    >
-      <span className="font-bold leading-snug text-[var(--color-fg)] group-hover:text-[var(--color-accent-hover)]">
-        {task.title}
-      </span>
-      {total > 0 ? (
-        <span className="text-xs font-bold text-[var(--color-dim)]">
-          {done} of {total} subtasks
+    <article className="group relative">
+      <button
+        ref={dragRef}
+        type="button"
+        onClick={() => onOpen(task)}
+        {...dragListeners}
+        aria-label={`Open task: ${task.title}`}
+        className={`flex w-full flex-col gap-2 rounded-lg bg-[var(--color-surface)] py-4 pl-4 pr-11 text-left shadow-sm transition-colors hover:bg-[var(--color-surface-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+          dragging ? "opacity-40" : ""
+        }`}
+      >
+        <span className="font-bold leading-snug text-[var(--color-fg)] group-hover:text-[var(--color-accent-hover)]">
+          {task.title}
         </span>
+        {total > 0 ? (
+          <span className="text-xs font-bold text-[var(--color-dim)]">
+            {done} of {total} subtasks
+          </span>
+        ) : null}
+      </button>
+
+      {hasActions ? (
+        <div className="absolute right-1.5 top-3.5">
+          <Menu
+            label={`Actions for ${task.title}`}
+            triggerClassName="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-dim)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+          >
+            {onMove
+              ? moveTargets.map((column) => (
+                  <MenuItem
+                    key={column.id}
+                    onSelect={() => onMove(task, column.name)}
+                  >
+                    Move to {column.name}
+                  </MenuItem>
+                ))
+              : null}
+            {onEdit ? (
+              <MenuItem onSelect={() => onEdit(task)}>Edit task</MenuItem>
+            ) : null}
+            {onDelete ? (
+              <MenuItem onSelect={() => onDelete(task)} destructive>
+                Delete task
+              </MenuItem>
+            ) : null}
+          </Menu>
+        </div>
       ) : null}
-    </button>
+    </article>
   );
 }

--- a/components/board/a11y.test.tsx
+++ b/components/board/a11y.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { axe } from "vitest-axe";
+import axe from "axe-core";
 import { TaskCard } from "./TaskCard";
 import { TaskModal } from "./TaskModal";
 import { Menu, MenuItem } from "@/components/ui/Menu";
@@ -11,7 +11,7 @@ import type { ColumnDTO, TaskDTO } from "@/lib/dto";
 // color-contrast can't be evaluated in jsdom (no layout/paint), so disable that
 // one rule and assert on everything else axe checks.
 async function expectNoViolations(node: Element) {
-  const { violations } = await axe(node, {
+  const { violations } = await axe.run(node, {
     rules: { "color-contrast": { enabled: false } },
   });
   if (violations.length > 0) {

--- a/components/board/a11y.test.tsx
+++ b/components/board/a11y.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { TaskCard } from "./TaskCard";
+import { TaskModal } from "./TaskModal";
+import { Menu, MenuItem } from "@/components/ui/Menu";
+import type { ColumnDTO, TaskDTO } from "@/lib/dto";
+
+// color-contrast can't be evaluated in jsdom (no layout/paint), so disable that
+// one rule and assert on everything else axe checks.
+async function expectNoViolations(node: Element) {
+  const { violations } = await axe(node, {
+    rules: { "color-contrast": { enabled: false } },
+  });
+  if (violations.length > 0) {
+    const detail = violations
+      .map((v) => `${v.id} (${v.impact}): ${v.help} [${v.nodes.length} node(s)]`)
+      .join("\n");
+    throw new Error(`Accessibility violations found:\n${detail}`);
+  }
+  expect(violations).toEqual([]);
+}
+
+const columns: ColumnDTO[] = [
+  { id: "c1", name: "todo", color: "" },
+  { id: "c2", name: "doing", color: "" },
+  { id: "c3", name: "done", color: "" },
+];
+
+const task: TaskDTO = {
+  id: "t1",
+  title: "Ship the accessibility pass",
+  description: "Make the board usable by keyboard and screen readers.",
+  status: { name: "todo", color: "" },
+  subtasks: [
+    { id: "s1", title: "Overlay stack", completed: true },
+    { id: "s2", title: "Card actions menu", completed: false },
+  ],
+};
+
+function renderCard() {
+  return render(
+    <TaskCard
+      task={task}
+      onOpen={() => {}}
+      columns={columns}
+      onMove={() => {}}
+      onEdit={() => {}}
+      onDelete={() => {}}
+    />,
+  );
+}
+
+describe("accessibility smoke tests", () => {
+  it("task card with an actions menu has no violations", async () => {
+    const { container } = renderCard();
+    await expectNoViolations(container);
+  });
+
+  it("task card with its actions menu open has no violations", async () => {
+    const { container } = renderCard();
+    await userEvent.click(
+      screen.getByRole("button", { name: /actions for/i }),
+    );
+    await expectNoViolations(container);
+  });
+
+  it("task modal has no violations", async () => {
+    // The modal renders through a portal, so assert against document.body.
+    const { baseElement } = render(
+      <TaskModal
+        task={task}
+        columns={columns}
+        onClose={() => {}}
+        onToggleSubtask={() => {}}
+        onChangeStatus={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    await expectNoViolations(baseElement);
+  });
+
+  it("standalone menu has no violations", async () => {
+    const { container } = render(
+      <Menu label="Row actions">
+        <MenuItem onSelect={() => {}}>Edit</MenuItem>
+        <MenuItem onSelect={() => {}} destructive>
+          Delete
+        </MenuItem>
+      </Menu>,
+    );
+    await expectNoViolations(container);
+  });
+});

--- a/components/ui/Menu.tsx
+++ b/components/ui/Menu.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
+import { useOverlayEscape } from "./overlayStack";
 
 // A small dropdown menu for the "..." action triggers (board, column, task).
 // Closes on outside click, on Escape (restoring focus to the trigger), and
@@ -40,6 +41,13 @@ export function Menu({ label, children, triggerClassName = "" }: MenuProps) {
       menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
     );
 
+  // Escape closes only this menu (restoring focus to the trigger) via the shared
+  // overlay stack, so it never leaks to a parent Modal when the menu is nested.
+  useOverlayEscape(open, () => {
+    close();
+    triggerRef.current?.focus();
+  });
+
   useEffect(() => {
     if (!open) return;
 
@@ -49,22 +57,10 @@ export function Menu({ label, children, triggerClassName = "" }: MenuProps) {
     function onPointerDown(event: MouseEvent) {
       if (!containerRef.current?.contains(event.target as Node)) close();
     }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        // Handled in the capture phase and stopped here so Escape dismisses
-        // only this menu, not a parent Modal whose own document-level Escape
-        // listener (registered earlier, on mount) would otherwise fire first.
-        event.stopPropagation();
-        close();
-        triggerRef.current?.focus();
-      }
-    }
 
     document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown, true);
     return () => {
       document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown, true);
     };
   }, [open]);
 

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { useOverlayEscape } from "./overlayStack";
 
 // A store that never changes: the snapshots alone distinguish server from client.
 const emptySubscribe = () => () => {};
@@ -53,6 +54,11 @@ export function Modal({
     getServerSnapshot,
   );
 
+  // Escape is handled through the shared overlay stack so a nested overlay (a
+  // menu inside this modal) closes only itself, and this modal closes only when
+  // it is the topmost overlay.
+  useOverlayEscape(open, onClose);
+
   useEffect(() => {
     if (!open) return;
 
@@ -61,12 +67,9 @@ export function Modal({
     const first = panel?.querySelector<HTMLElement>(FOCUSABLE);
     (first ?? panel)?.focus();
 
+    // Only the Tab focus-trap lives here now; Escape is owned by the overlay
+    // stack above.
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return;
-      }
       if (event.key !== "Tab" || !panel) return;
 
       const items = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE));

--- a/components/ui/overlayStack.test.tsx
+++ b/components/ui/overlayStack.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { useOverlayEscape, overlayStackSize } from "./overlayStack";
+
+// A bare overlay whose only job is to register an Escape handler while active.
+function Overlay({ active, onEscape }: { active: boolean; onEscape: () => void }) {
+  useOverlayEscape(active, onEscape);
+  return null;
+}
+
+describe("overlay stack", () => {
+  it("routes Escape to only the topmost active overlay", () => {
+    const outer = vi.fn();
+    const inner = vi.fn();
+
+    const { rerender } = render(
+      <>
+        <Overlay active onEscape={outer} />
+        <Overlay active={false} onEscape={inner} />
+      </>,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(outer).toHaveBeenCalledTimes(1);
+    expect(inner).not.toHaveBeenCalled();
+
+    // Open the inner overlay: pushed last, so it is now topmost.
+    rerender(
+      <>
+        <Overlay active onEscape={outer} />
+        <Overlay active onEscape={inner} />
+      </>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(outer).toHaveBeenCalledTimes(1); // unchanged: no longer topmost
+
+    // Close the inner overlay: Escape falls back to the outer one.
+    rerender(
+      <>
+        <Overlay active onEscape={outer} />
+        <Overlay active={false} onEscape={inner} />
+      </>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(outer).toHaveBeenCalledTimes(2);
+    expect(inner).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-Escape keys and drains the stack on unmount", () => {
+    const onEscape = vi.fn();
+    const { unmount } = render(<Overlay active onEscape={onEscape} />);
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(overlayStackSize()).toBe(1);
+
+    unmount();
+    expect(overlayStackSize()).toBe(0);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+});

--- a/components/ui/overlayStack.ts
+++ b/components/ui/overlayStack.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useId, useRef } from "react";
+
+// A shared registry for stacked overlays (modals, menus). Each open overlay
+// registers an Escape handler; a single capture-phase document listener routes
+// Escape to only the *topmost* overlay and stops it there. This replaces each
+// overlay wiring its own document listener — which only worked for one exact
+// nesting (a menu inside a modal) and broke for any deeper or repeated stack.
+
+interface OverlayEntry {
+  id: string;
+  onEscape: () => void;
+}
+
+const stack: OverlayEntry[] = [];
+let listening = false;
+
+function handleKeyDown(event: KeyboardEvent) {
+  if (event.key !== "Escape" || stack.length === 0) return;
+  // Only the topmost overlay reacts, and it consumes the event so it never
+  // reaches a parent overlay or the document below.
+  event.preventDefault();
+  event.stopPropagation();
+  stack[stack.length - 1].onEscape();
+}
+
+function startListening() {
+  if (listening) return;
+  document.addEventListener("keydown", handleKeyDown, true);
+  listening = true;
+}
+
+function stopListening() {
+  if (!listening) return;
+  document.removeEventListener("keydown", handleKeyDown, true);
+  listening = false;
+}
+
+// Exposed for tests to assert the stack drains on unmount.
+export function overlayStackSize() {
+  return stack.length;
+}
+
+// Registers `onEscape` as the Escape handler while `active` is true, pushing it
+// onto the shared stack on activate and popping it on deactivate/unmount. The
+// latest `onEscape` is always called, without re-ordering the stack on every
+// render.
+export function useOverlayEscape(active: boolean, onEscape: () => void) {
+  const id = useId();
+  const handlerRef = useRef(onEscape);
+
+  useEffect(() => {
+    handlerRef.current = onEscape;
+  });
+
+  useEffect(() => {
+    if (!active) return;
+    const entry: OverlayEntry = { id, onEscape: () => handlerRef.current() };
+    stack.push(entry);
+    startListening();
+    return () => {
+      const index = stack.findIndex((item) => item.id === entry.id);
+      if (index !== -1) stack.splice(index, 1);
+      if (stack.length === 0) stopListening();
+    };
+  }, [active, id]);
+}

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+// Reports the user's "reduce motion" OS setting, updating live if it changes.
+// SSR-safe via useSyncExternalStore: the server snapshot is `false` (assume
+// motion is allowed) and the client subscribes to the media query.
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(callback: () => void) {
+  const media = window.matchMedia(QUERY);
+  media.addEventListener("change", callback);
+  return () => media.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function usePrefersReducedMotion() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/nodemailer": "^8.0.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "axe-core": "^4.12.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.9",
         "husky": "^9.1.7",
@@ -41,8 +42,7 @@
         "lint-staged": "^17.0.8",
         "tailwindcss": "^4",
         "typescript": "^5",
-        "vitest": "^4.1.9",
-        "vitest-axe": "^0.1.0"
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4616,7 +4616,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -7167,13 +7168,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9817,37 +9811,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/vitest-axe": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
-      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aria-query": "^5.0.0",
-        "axe-core": "^4.4.2",
-        "chalk": "^5.0.1",
-        "dom-accessibility-api": "^0.5.14",
-        "lodash-es": "^4.17.21",
-        "redent": "^3.0.0"
-      },
-      "peerDependencies": {
-        "vitest": ">=0.16.0"
-      }
-    },
-    "node_modules/vitest-axe/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "lint-staged": "^17.0.8",
         "tailwindcss": "^4",
         "typescript": "^5",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.9",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4615,8 +4616,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -7167,6 +7167,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9810,6 +9817,37 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint-staged": "^17.0.8",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/nodemailer": "^8.0.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "axe-core": "^4.12.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.9",
     "husky": "^9.1.7",
@@ -46,7 +47,6 @@
     "lint-staged": "^17.0.8",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^4.1.9",
-    "vitest-axe": "^0.1.0"
+    "vitest": "^4.1.9"
   }
 }


### PR DESCRIPTION
## Problem

PR #14 shipped board/column/task CRUD and dnd-kit drag but deliberately deferred accessibility and mobile to a dedicated slice (a hard requirement). Three concrete gaps:

1. **No non-pointer way to move a task.** The board wired only `PointerSensor`, and `DraggableTaskCard` intentionally spread only dnd-kit `listeners` (not `attributes`) — so keyboard and screen-reader users had *no* way to move a task between columns, and drag was silent to assistive tech.
2. **The overlay Escape mechanism was an ad-hoc two-listener hack.** `Modal` listened for Escape on `document` (bubble), and `Menu` listened on `document` (capture) with `stopPropagation` so its Escape wouldn't leak to a parent modal. That worked for exactly one nesting (a menu inside a modal) and would break for any third overlay or two stacked menus.
3. **No motion-preference handling.** Sonner toasts, Tailwind transitions, and the drag drop tween all ran unconditionally.

## Approach

- **First-class Move control.** Each task card grows a "…" actions menu whose **"Move to `<column>`"** items are the keyboard/screen-reader move path (plus Edit/Delete); the task modal's status `<select>` stays as the in-modal move. `TaskCard` becomes an `<article>` with the primary open-`<button>` and a sibling `Menu` (no invalid button-in-button). Drag stays pointer-only and now emits **screen-reader live-region announcements** via `DndContext` `accessibility`.
- **Shared overlay-stack registry** (`components/ui/overlayStack.ts`). A single capture-phase document listener routes Escape to only the *topmost* overlay and consumes it there. `Modal` and `Menu` both use the `useOverlayEscape(active, onEscape)` hook; the bespoke listeners are gone. Now a menu-in-modal, modal-in-modal, or menu-in-menu all close only the frontmost layer.
- **Touch drag that doesn't fight scroll.** Split the lone `PointerSensor` into `MouseSensor` (unchanged 5px feel) + `TouchSensor` (press-and-hold: `delay 250, tolerance 8`); dropped `touch-none` from cards so a tap opens and a swipe scrolls. On mobile the card's "Move to" menu is the reliable move path.
- **`prefers-reduced-motion`.** A global CSS media query neutralizes transitions/animations (covers sonner + Tailwind in one place); an SSR-safe `usePrefersReducedMotion` hook also drops the dnd-kit drop animation and lift rotation.
- **Focus/labels.** The columns row is a labelled, keyboard-focusable `region`; the card open-button gets an explicit `aria-label`.
- **Automated a11y gate.** Adds `vitest-axe` smoke tests over the task card (incl. open menu), the task modal, and the menu.

## Tradeoffs / alternatives considered

- **Move menu over "real" dnd-kit keyboard drag.** A `KeyboardSensor` + grab handle was rejected: it fights the discrete-column model (default 25px spatial steps), can't reorder within a column anyway (the embedded model has no per-column order), and duplicates a worse version of what a named "Move to X" control does. The menu is discoverable, robust, and honest about the data model.
- **Within-column reordering still deferred** — same reason as PR #14 (no order field in the embedded document).
- **Overlay registry vs. a focus-trap library.** Kept the hand-rolled Modal/Menu and added just a small shared Escape registry rather than pulling in a headless-UI dependency, to keep the primitives legible and dependency-light.
- **vitest-axe assertion style.** vitest-axe 0.1.0 re-exports its matchers as `export type *` (type-only), which breaks `expect.extend(...)` typing. Rather than fight it, the tests call `axe()` directly with a small explicit assertion helper (color-contrast disabled — jsdom can't compute layout). Same coverage, no global-augmentation fragility.

## Testing

- `npm run lint && npm run typecheck && npm run build` clean. (The Next TS-plugin `71007` "serializable props" warnings on `DraggableTaskCard` are the known false positives — a client component imported by another client component, not a real server/client entry; the real `next build` is clean.)
- `npm test` green: **94 passing** (was 86). New: overlay-stack registry (topmost-only Escape + drain-on-unmount), card actions menu (Move excludes current column; Move/Edit/Delete fire), and 4 vitest-axe smoke tests.
- **Interactive checks pending in an authenticated session** (they need a logged-in board, which I don't self-authenticate into): keyboard traversal board → card → "Move to" with visible focus throughout; Escape closes only a nested menu while its modal stays open, and closes the modal when it's topmost; touch tap-vs-hold-vs-swipe on a device/emulator; and OS "reduce motion" quieting the toasts/drop tween. Happy to drive these with you before merge.

Assisted-by: Claude (Opus 4.8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard-based task movement from each card’s actions menu.
  * Improved drag-and-drop feedback with screen-reader announcements and better touch handling.
  * Added support for reduced-motion preferences across the board.
* **Bug Fixes**
  * Escape now closes only the topmost open menu or modal.
  * The board columns area is now easier to focus and navigate with a keyboard.
* **Tests**
  * Added accessibility checks for task cards, menus, and task dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->