### PR TITLE
docs(release): finalize v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-01
+
+First production release of the v2 rebuild: a single Next.js 16 app deployed on Vercel with
+MongoDB Atlas, replacing the retired Vue/Quasar + Express (Render) stack.
+
 ### Added
 
 - Board interactivity: create/edit/delete dialogs for boards, columns (with a color

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ optimistic updates, and a keyboard/screen-reader-accessible move path.
 
 [![CI](https://github.com/jeramiahgcoffey/kboards/actions/workflows/ci.yml/badge.svg)](https://github.com/jeramiahgcoffey/kboards/actions/workflows/ci.yml)
 
-- **Live:** _coming with the v2.0.0 release_
+- **Live:** [kboards.jeramiahcoffey.com](https://kboards.jeramiahcoffey.com)
 - **Source:** [github.com/jeramiahgcoffey/kboards](https://github.com/jeramiahgcoffey/kboards)
 
-> _Demo GIF coming with the v2.0.0 release._
+> _Demo GIF coming soon._
 
 kboards started in 2023 as a Vue 3 / Quasar 2 client plus a separate Express + TypeScript API. It is
 being rebuilt in 2026 as a single **Next.js 16** full-stack app — the flagship "maintenance and


### PR DESCRIPTION
## Problem
The v2 rebuild is now deployed to production (Vercel + Atlas + Resend) at https://kboards.jeramiahcoffey.com, but the repo docs still read pre-release: the CHANGELOG kept everything under `[Unreleased]` and the README live link was a placeholder.

## Approach
- CHANGELOG: cut the `[Unreleased]` entries as `## [2.0.0] - 2026-07-01` with a one-line release summary; opened a fresh empty `[Unreleased]`.
- README: live link now points at the deployed site.

## Tradeoffs / alternatives considered
Docs-only; no code change. The demo GIF is intentionally deferred (placeholder reads "coming soon") rather than blocking the tag on a recording.

## Testing
N/A (docs). Production deployment verified healthy out-of-band: landing 200, `/boards` gates to `/login` on the custom domain, DB reset probe 200 (Mongo connected), and a manual register → board CRUD → drag/move → password-reset-email smoke test passed.

Assisted-by: Claude (Opus 4.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new changelog entry for version 2.0.0, marking the first production release of the rebuilt app.
  * Updated the README with current live and source links.
  * Revised demo messaging to reflect that the live deployment is available and the demo GIF is still coming soon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->