### PR TITLE
release: v2.1.0 — within-column reordering + brand polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-02
+
+A polish-and-feature release: task cards can now be reordered within a column, and the app
+gains a real brand identity (logo mark, favicon, and social share image).
+
+### Added
+
+- Within-column task reordering. Cards can be dragged to a new position inside their column
+  (previously drag only moved a task between columns), and the same drag can drop a card into
+  another column at a chosen position. Order is persisted on a new `order` field on the
+  embedded task model and surfaced through the DTO, which now emits each column's tasks
+  pre-sorted. A single idempotent `PATCH /api/boards/:id/tasks/reorder` endpoint applies a
+  column's full desired order, so reordering and cross-column drop-at-position share one
+  operation; updates are optimistic and roll back on failure. Cards use dnd-kit's sortable
+  wiring, and the keyboard/screen-reader path is each card's "Move up"/"Move down" menu items
+  (mirroring the existing "Move to <column>"). New tasks and column moves append to the bottom
+  of their column. Covered by service, DTO, optimistic, and component tests, and verified end
+  to end in a browser (drag reorder, cross-column drop, and the accessible menu all persist).
+- Brand identity and metadata. A three-column logo mark (reused across the landing hero,
+  sidebar, and mobile header), a code-generated favicon (`app/icon.svg`), apple-touch icon,
+  and a 1200×630 Open Graph / Twitter share image rendered from the same mark via
+  `next/og` — so the brand never drifts from a committed binary. Adds a web app manifest and
+  fills in `openGraph`/`twitter` metadata with an absolute `metadataBase`.
+
+### Changed
+
+- Visual polish: a subtle accent glow behind the app background and themed thin scrollbars for
+  the horizontal board, and the landing/sidebar/header now show the real logo mark in place of
+  the placeholder square.
+
 ## [2.0.0] - 2026-07-01
 
 First production release of the v2 rebuild: a single Next.js 16 app deployed on Vercel with

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ iteration" portfolio project. The rebuild is tracked visibly through commits, AD
 
 - **Boards, columns, tasks, subtasks** — full CRUD through nested REST Route Handlers behind an
   ownership-scoped service layer.
-- **Drag-and-drop** — move tasks between columns (pointer), with optimistic updates and rollback on
-  failure.
+- **Drag-and-drop** — reorder tasks within a column and move them between columns (pointer), with
+  optimistic updates and rollback on failure. Keyboard/screen-reader users get the same moves from
+  each card's "Move up/down" and "Move to <column>" menu.
 - **Accessible by design** — every task can also be moved from a keyboard/screen-reader "…" menu;
   stacked overlays share one Escape/focus registry; `prefers-reduced-motion` is respected.
 - **Authentication** — email/password (Auth.js v5, Credentials + JWT sessions) with a custom

--- a/app/api/boards/[boardId]/tasks/reorder/route.ts
+++ b/app/api/boards/[boardId]/tasks/reorder/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { authed, readJson } from "@/lib/api/route";
+import { taskReorderSchema } from "@/lib/validation";
+import { reorderColumn } from "@/lib/services/tasks";
+import { toBoard } from "@/lib/dto";
+
+// A static sibling of `tasks/[taskId]`; Next matches this exact path first, so
+// "reorder" is never treated as a task id.
+type Params = { boardId: string };
+
+export const PATCH = authed<Params>(async ({ request, userId, params }) => {
+  const input = taskReorderSchema.parse(await readJson(request));
+  const board = await reorderColumn(userId, params.boardId, input);
+  return NextResponse.json({ board: toBoard(board) });
+});

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,31 @@
+import { ImageResponse } from "next/og";
+
+// Apple touch icon (home-screen bookmark on iOS). Generated from code so the
+// brand mark stays the single source of truth — no separate binary to keep in
+// sync. Rendered at 180×180, Apple's recommended size.
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          gap: 12,
+          padding: "44px 30px",
+          background: "#0f1115",
+        }}
+      >
+        <div style={{ width: 34, height: 92, borderRadius: 12, background: "#635fc7" }} />
+        <div style={{ width: 34, height: 60, borderRadius: 12, background: "#49c4e5" }} />
+        <div style={{ width: 34, height: 76, borderRadius: 12, background: "#67e2ae" }} />
+      </div>
+    ),
+    size,
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,13 +19,43 @@ html {
 }
 
 body {
-  background: var(--color-bg);
+  /* A faint accent glow at the top-left lifts the flat dark fill without
+     competing with content; the base color still shows through everywhere. */
+  background:
+    radial-gradient(
+      1200px 600px at 0% -10%,
+      color-mix(in srgb, var(--color-accent) 12%, transparent),
+      transparent 60%
+    ),
+    var(--color-bg);
+  background-attachment: fixed;
   color: var(--color-fg);
   -webkit-font-smoothing: antialiased;
 }
 
 ::selection {
   background: color-mix(in srgb, var(--color-accent) 40%, transparent);
+}
+
+/* Themed, unobtrusive scrollbars so the horizontal board and long columns match
+   the dark surface instead of showing the OS default light track. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-line) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--color-line);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--color-surface-2);
+  background-clip: content-box;
 }
 
 /* Honor the OS "reduce motion" setting everywhere: neutralize transitions and

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#0f1115" />
+  <rect x="5" y="7" width="6.5" height="18" rx="2.2" fill="#635fc7" />
+  <rect x="12.75" y="7" width="6.5" height="12" rx="2.2" fill="#49c4e5" />
+  <rect x="20.5" y="7" width="6.5" height="15" rx="2.2" fill="#67e2ae" />
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,30 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://kboards.jeramiahcoffey.com";
+
 export const metadata: Metadata = {
+  // Resolves the file-convention icon / OG image routes to absolute URLs, which
+  // social crawlers require.
+  metadataBase: new URL(siteUrl),
   title: {
     default: "kboards",
     template: "%s · kboards",
   },
   description: "A kanban board for tracking work, rebuilt in Next.js.",
+  applicationName: "kboards",
+  openGraph: {
+    type: "website",
+    siteName: "kboards",
+    url: siteUrl,
+    title: "kboards",
+    description: "A kanban board for tracking work, rebuilt in Next.js.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "kboards",
+    description: "A kanban board for tracking work, rebuilt in Next.js.",
+  },
 };
 
 export const viewport: Viewport = {

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+
+// Web app manifest, so the app is installable and its standalone window / splash
+// use the brand colors. Icons point at the file-convention routes Next serves.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "kboards",
+    short_name: "kboards",
+    description: "A kanban board for tracking work.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0f1115",
+    theme_color: "#0f1115",
+    icons: [
+      { src: "/icon.svg", type: "image/svg+xml", sizes: "any" },
+      { src: "/apple-icon", type: "image/png", sizes: "180x180" },
+    ],
+  };
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,48 @@
+import { ImageResponse } from "next/og";
+
+// Social share image (Open Graph + Twitter). Generated from code so it never
+// drifts from the brand mark and needs no committed binary. Next wires this into
+// og:image / twitter:image automatically via the file convention.
+export const alt = "kboards — a kanban board for tracking work";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "96px",
+          background:
+            "linear-gradient(135deg, #0f1115 0%, #171a21 55%, #1f2430 100%)",
+          color: "#e7eaf0",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 18 }}>
+          <div style={{ width: 56, height: 150, borderRadius: 18, background: "#635fc7" }} />
+          <div style={{ width: 56, height: 98, borderRadius: 18, background: "#49c4e5" }} />
+          <div style={{ width: 56, height: 124, borderRadius: 18, background: "#67e2ae" }} />
+        </div>
+        <div
+          style={{
+            marginTop: 56,
+            fontSize: 104,
+            fontWeight: 800,
+            letterSpacing: "-0.03em",
+          }}
+        >
+          kboards
+        </div>
+        <div style={{ marginTop: 12, fontSize: 40, color: "#9aa3b2" }}>
+          A kanban board for tracking work.
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,21 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
+import { LogoMark } from "@/components/ui/Logo";
 
 export default async function Home() {
   if (await auth()) redirect("/boards");
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col justify-center gap-6 px-6">
-      <div className="flex items-center gap-2">
-        <span aria-hidden className="h-7 w-7 rounded bg-[var(--color-accent)]" />
+      <div className="flex items-center gap-3">
+        <LogoMark className="h-9 w-9" title="kboards" />
         <h1 className="text-3xl font-bold tracking-tight">kboards</h1>
       </div>
-      <p className="max-w-prose text-[var(--color-dim)]">
+      <p className="max-w-prose text-lg text-[var(--color-dim)]">
         A kanban board for tracking work. Create boards, organize tasks into
-        columns, and break work into subtasks.
+        columns, break work into subtasks, and drag to reorder as priorities
+        shift.
       </p>
       <div className="flex flex-wrap gap-3">
         <Link

--- a/components/board/AppShell.tsx
+++ b/components/board/AppShell.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from "react";
 import type { BoardSummaryDTO } from "@/lib/dto";
 import { Modal } from "@/components/ui/Modal";
+import { LogoMark } from "@/components/ui/Logo";
 import { Sidebar } from "./Sidebar";
 import { SignOutButton } from "./SignOutButton";
 
@@ -66,6 +67,9 @@ export function AppShell({
                 </svg>
               </button>
             ) : null}
+            {/* The sidebar (and its brand mark) is hidden on small screens, so
+                surface the mark in the header there to keep the app branded. */}
+            <LogoMark className="h-6 w-6 shrink-0 lg:hidden" title="kboards" />
             <h1 className="truncate text-lg font-bold tracking-tight sm:text-xl">
               {title}
             </h1>

--- a/components/board/BoardWorkspace.tsx
+++ b/components/board/BoardWorkspace.tsx
@@ -7,7 +7,7 @@ import {
   DragOverlay,
   MouseSensor,
   TouchSensor,
-  pointerWithin,
+  closestCorners,
   useSensor,
   useSensors,
   type Announcements,
@@ -15,10 +15,15 @@ import {
   type DragStartEvent,
   type ScreenReaderInstructions,
 } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
 import { toast } from "sonner";
 import type { BoardDTO, ColumnDTO, TaskDTO } from "@/lib/dto";
 import { apiFetch, errorMessage } from "@/lib/api/client";
-import { withMovedTask, withToggledSubtask } from "@/lib/board/optimistic";
+import {
+  withMovedTask,
+  withReorderedColumn,
+  withToggledSubtask,
+} from "@/lib/board/optimistic";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { Button } from "@/components/ui/Button";
 import { Menu, MenuItem } from "@/components/ui/Menu";
@@ -62,8 +67,13 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
     board.tasks.find((task) => task.id === selectedTaskId) ?? null;
   const closeDialog = () => setDialog({ type: "none" });
 
+  // Tasks in a column, in display order. The DTO already arrives sorted, but
+  // sorting here too keeps the view correct after an optimistic reorder rewrites
+  // order values on the current board.
   const tasksFor = (name: string) =>
-    board.tasks.filter((task) => task.status.name === name);
+    board.tasks
+      .filter((task) => task.status.name === name)
+      .sort((a, b) => a.order - b.order);
 
   // --- Mutations that return the updated board ---------------------------
 
@@ -250,6 +260,37 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
     }
   }
 
+  // Apply a new order for one column optimistically, then persist it. On failure
+  // the pre-reorder board is restored, but only if no newer mutation has since
+  // started (guarded by the token), so a slow rollback can't clobber a newer
+  // change. `orderedTaskIds` is the column's full desired order.
+  async function reorderColumn(columnName: string, orderedTaskIds: string[]) {
+    const previous = board;
+    const token = ++mutationToken.current;
+    setBoard((current) =>
+      withReorderedColumn(current, columnName, orderedTaskIds),
+    );
+    try {
+      await apiFetch(`/api/boards/${boardId}/tasks/reorder`, {
+        method: "PATCH",
+        body: { columnName, orderedTaskIds },
+      });
+    } catch (error) {
+      if (token === mutationToken.current) setBoard(previous);
+      toast.error(errorMessage(error, "Could not reorder the tasks."));
+    }
+  }
+
+  // The keyboard/screen-reader reorder path (each card's "Move up"/"Move down"):
+  // swap the task with its neighbor within its column and persist the new order.
+  function reorderTaskByStep(task: TaskDTO, direction: "up" | "down") {
+    const ids = tasksFor(task.status.name).map((item) => item.id);
+    const index = ids.indexOf(task.id);
+    const target = direction === "up" ? index - 1 : index + 1;
+    if (index === -1 || target < 0 || target >= ids.length) return;
+    void reorderColumn(task.status.name, arrayMove(ids, index, target));
+  }
+
   // --- Drag and drop ----------------------------------------------------
 
   const reducedMotion = usePrefersReducedMotion();
@@ -266,7 +307,12 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
 
   const taskTitle = (id: string) =>
     board.tasks.find((item) => item.id === id)?.title ?? "task";
-  const columnFromOverId = (overId: string) => overId.replace(/^col:/, "");
+  // A drop target is either a column droppable ("col:<name>") or another task
+  // card; resolve both to the destination column's name.
+  const columnNameFromOver = (overId: string): string | null =>
+    overId.startsWith("col:")
+      ? overId.slice("col:".length)
+      : (board.tasks.find((item) => item.id === overId)?.status.name ?? null);
 
   // Live-region messages so assistive tech follows a pointer drag; the discrete
   // keyboard/screen-reader move path is each card's "Move to" menu.
@@ -276,14 +322,16 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
     },
     onDragOver({ active, over }) {
       const name = taskTitle(String(active.id));
-      return over
-        ? `Task ${name} is over the ${columnFromOverId(String(over.id))} column.`
+      const to = over ? columnNameFromOver(String(over.id)) : null;
+      return to
+        ? `Task ${name} is over the ${to} column.`
         : `Task ${name} is not over a column.`;
     },
     onDragEnd({ active, over }) {
       const name = taskTitle(String(active.id));
-      return over
-        ? `Task ${name} was moved to the ${columnFromOverId(String(over.id))} column.`
+      const to = over ? columnNameFromOver(String(over.id)) : null;
+      return to
+        ? `Task ${name} was dropped in the ${to} column.`
         : `Task ${name} was dropped without moving.`;
     },
     onDragCancel({ active }) {
@@ -306,7 +354,34 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
     setActiveDragTask(null);
     const { active, over } = event;
     if (!over) return;
-    void moveTask(String(active.id), columnFromOverId(String(over.id)));
+
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    const activeTask = board.tasks.find((item) => item.id === activeId);
+    const toColumn = columnNameFromOver(overId);
+    if (!activeTask || !toColumn) return;
+
+    const targetIds = tasksFor(toColumn).map((item) => item.id);
+    // Dropping on a column's background (rather than a card) targets its end.
+    const droppedOnColumn = overId.startsWith("col:");
+
+    if (activeTask.status.name === toColumn) {
+      // Reorder within the same column.
+      const oldIndex = targetIds.indexOf(activeId);
+      const newIndex = droppedOnColumn
+        ? targetIds.length - 1
+        : targetIds.indexOf(overId);
+      if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
+      void reorderColumn(toColumn, arrayMove(targetIds, oldIndex, newIndex));
+    } else {
+      // Move into another column at the drop position, inserting before the card
+      // under the pointer (or at the end when dropped on the column background).
+      const overIndex = droppedOnColumn ? -1 : targetIds.indexOf(overId);
+      const insertAt = overIndex === -1 ? targetIds.length : overIndex;
+      const next = [...targetIds];
+      next.splice(insertAt, 0, activeId);
+      void reorderColumn(toColumn, next);
+    }
   }
 
   // --- Render -----------------------------------------------------------
@@ -343,7 +418,7 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
       {hasColumns ? (
         <DndContext
           sensors={sensors}
-          collisionDetection={pointerWithin}
+          collisionDetection={closestCorners}
           accessibility={{ announcements, screenReaderInstructions }}
           onDragStart={onDragStart}
           onDragEnd={onDragEnd}
@@ -365,6 +440,9 @@ export function BoardWorkspace({ board: initialBoard }: { board: BoardDTO }) {
                 onOpenTask={(task) => setSelectedTaskId(task.id)}
                 onMoveTask={(task, toColumnName) =>
                   moveTask(task.id, toColumnName)
+                }
+                onReorderTask={(task, direction) =>
+                  reorderTaskByStep(task, direction)
                 }
                 onEditTask={(task) =>
                   setDialog({ type: "edit-task", taskId: task.id })

--- a/components/board/Column.tsx
+++ b/components/board/Column.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useDroppable } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import type { ColumnDTO, TaskDTO } from "@/lib/dto";
 import { Menu, MenuItem } from "@/components/ui/Menu";
 import { columnAccent } from "./colors";
@@ -14,6 +18,7 @@ interface ColumnProps {
   columns: ColumnDTO[];
   onOpenTask: (task: TaskDTO) => void;
   onMoveTask: (task: TaskDTO, toColumnName: string) => void;
+  onReorderTask: (task: TaskDTO, direction: "up" | "down") => void;
   onEditTask: (task: TaskDTO) => void;
   onDeleteTask: (task: TaskDTO) => void;
   onEditColumn: (column: ColumnDTO) => void;
@@ -27,6 +32,7 @@ export function Column({
   columns,
   onOpenTask,
   onMoveTask,
+  onReorderTask,
   onEditTask,
   onDeleteTask,
   onEditColumn,
@@ -74,17 +80,24 @@ export function Column({
             No tasks yet
           </p>
         ) : (
-          tasks.map((task) => (
-            <DraggableTaskCard
-              key={task.id}
-              task={task}
-              columns={columns}
-              onOpen={onOpenTask}
-              onMove={onMoveTask}
-              onEdit={onEditTask}
-              onDelete={onDeleteTask}
-            />
-          ))
+          <SortableContext
+            items={tasks.map((task) => task.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {tasks.map((task, taskIndex) => (
+              <DraggableTaskCard
+                key={task.id}
+                task={task}
+                columns={columns}
+                position={{ index: taskIndex, count: tasks.length }}
+                onOpen={onOpenTask}
+                onMove={onMoveTask}
+                onReorder={onReorderTask}
+                onEdit={onEditTask}
+                onDelete={onDeleteTask}
+              />
+            ))}
+          </SortableContext>
         )}
       </div>
     </section>

--- a/components/board/DraggableTaskCard.tsx
+++ b/components/board/DraggableTaskCard.tsx
@@ -1,45 +1,64 @@
 "use client";
 
-import { useDraggable } from "@dnd-kit/core";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { ColumnDTO, TaskDTO } from "@/lib/dto";
 import { TaskCard } from "./TaskCard";
 
-// Wraps a task card with pointer-drag wiring. Only `listeners` (pointer events)
-// are spread onto the card, not dnd-kit's keyboard `attributes`: the card stays
-// a plain button whose keyboard/screen-reader move path is the card's "..."
-// actions menu ("Move to <column>"), while pointer users can additionally drag
-// it between columns.
+// Wraps a task card with pointer drag-and-sort wiring. Only `listeners` (pointer
+// events) are spread onto the card, not dnd-kit's keyboard `attributes`: the
+// card stays a plain button whose keyboard/screen-reader move path is the card's
+// "..." menu ("Move to <column>", "Move up/down"), while pointer users can drag
+// it to another column or to a new position within its column.
 export function DraggableTaskCard({
   task,
   onOpen,
   columns,
+  position,
   onMove,
+  onReorder,
   onEdit,
   onDelete,
 }: {
   task: TaskDTO;
   onOpen: (task: TaskDTO) => void;
   columns: ColumnDTO[];
+  // The card's index and count within its column, so the menu can offer/limit
+  // "Move up"/"Move down" at the column ends.
+  position: { index: number; count: number };
   onMove: (task: TaskDTO, toColumnName: string) => void;
+  onReorder: (task: TaskDTO, direction: "up" | "down") => void;
   onEdit: (task: TaskDTO) => void;
   onDelete: (task: TaskDTO) => void;
 }) {
-  const { setNodeRef, listeners, isDragging } = useDraggable({
-    id: task.id,
-    data: { fromColumn: task.status.name },
-  });
+  const {
+    setNodeRef,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: task.id, data: { fromColumn: task.status.name } });
 
+  // The sortable node (this wrapper) is what dnd-kit measures and transforms as
+  // siblings shift to make room; the transform must apply here, not to the inner
+  // button, so the card's absolutely-positioned actions menu travels with it.
   return (
-    <TaskCard
-      task={task}
-      onOpen={onOpen}
-      dragRef={setNodeRef}
-      dragListeners={listeners}
-      dragging={isDragging}
-      columns={columns}
-      onMove={onMove}
-      onEdit={onEdit}
-      onDelete={onDelete}
-    />
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+    >
+      <TaskCard
+        task={task}
+        onOpen={onOpen}
+        dragListeners={listeners}
+        dragging={isDragging}
+        columns={columns}
+        position={position}
+        onMove={onMove}
+        onReorder={onReorder}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    </div>
   );
 }

--- a/components/board/Sidebar.tsx
+++ b/components/board/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type { BoardSummaryDTO } from "@/lib/dto";
+import { LogoMark } from "@/components/ui/Logo";
 import { CreateBoardButton } from "./CreateBoardButton";
 
 interface SidebarProps {
@@ -15,7 +16,7 @@ export function Sidebar({ boards, activeBoardId, onNavigate }: SidebarProps) {
   return (
     <div className="flex h-full flex-col gap-6 py-6">
       <div className="flex items-center gap-2 px-6">
-        <span aria-hidden className="h-5 w-5 rounded bg-[var(--color-accent)]" />
+        <LogoMark className="h-6 w-6" />
         <span className="text-lg font-bold tracking-tight">kboards</span>
       </div>
 

--- a/components/board/TaskCard.test.tsx
+++ b/components/board/TaskCard.test.tsx
@@ -16,6 +16,7 @@ function makeTask(overrides: Partial<TaskDTO> = {}): TaskDTO {
     id: "t1",
     title: "Build the board view",
     status: { name: "todo", color: "" },
+    order: 0,
     subtasks: [
       { id: "s1", title: "Columns", completed: true },
       { id: "s2", title: "Cards", completed: false },
@@ -101,5 +102,43 @@ describe("TaskCard", () => {
       screen.getByRole("menuitem", { name: /delete task/i }),
     );
     expect(onDelete).toHaveBeenCalledWith(task);
+  });
+
+  it("offers reorder items scoped to the card's position in its column", async () => {
+    const onReorder = vi.fn();
+    const task = makeTask();
+
+    // First of three: only "Move down" is available.
+    const first = render(
+      <TaskCard
+        task={task}
+        onOpen={vi.fn()}
+        position={{ index: 0, count: 3 }}
+        onReorder={onReorder}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /actions for build the board view/i }),
+    );
+    expect(screen.queryByRole("menuitem", { name: /move up/i })).toBeNull();
+    await userEvent.click(screen.getByRole("menuitem", { name: /move down/i }));
+    expect(onReorder).toHaveBeenCalledWith(task, "down");
+    first.unmount();
+
+    // Last of three: only "Move up" is available.
+    render(
+      <TaskCard
+        task={task}
+        onOpen={vi.fn()}
+        position={{ index: 2, count: 3 }}
+        onReorder={onReorder}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /actions for build the board view/i }),
+    );
+    expect(screen.queryByRole("menuitem", { name: /move down/i })).toBeNull();
+    await userEvent.click(screen.getByRole("menuitem", { name: /move up/i }));
+    expect(onReorder).toHaveBeenCalledWith(task, "up");
   });
 });

--- a/components/board/TaskCard.tsx
+++ b/components/board/TaskCard.tsx
@@ -11,10 +11,16 @@ interface TaskCardProps {
   dragListeners?: DraggableSyntheticListeners;
   dragging?: boolean;
   // Optional on-card actions. When provided, the card grows a "..." menu whose
-  // "Move to" items are the keyboard/screen-reader path to move a task (pointer
-  // users can also drag). Omitted for the drag overlay and static/test renders.
+  // "Move up/down" items reorder the task within its column and whose "Move to"
+  // items move it to another column — together the keyboard/screen-reader path
+  // for the moves pointer users make by dragging. Omitted for the drag overlay
+  // and static/test renders.
   columns?: ColumnDTO[];
+  // The card's index and count within its column, so reorder items can be
+  // limited at the ends. Present whenever onReorder is.
+  position?: { index: number; count: number };
   onMove?: (task: TaskDTO, toColumnName: string) => void;
+  onReorder?: (task: TaskDTO, direction: "up" | "down") => void;
   onEdit?: (task: TaskDTO) => void;
   onDelete?: (task: TaskDTO) => void;
 }
@@ -26,16 +32,22 @@ export function TaskCard({
   dragListeners,
   dragging = false,
   columns,
+  position,
   onMove,
+  onReorder,
   onEdit,
   onDelete,
 }: TaskCardProps) {
   const total = task.subtasks.length;
   const done = task.subtasks.filter((subtask) => subtask.completed).length;
-  const hasActions = Boolean(onMove || onEdit || onDelete);
+  const hasActions = Boolean(onMove || onReorder || onEdit || onDelete);
   // Every column except the one the task already sits in.
   const moveTargets =
     columns?.filter((column) => column.name !== task.status.name) ?? [];
+  const canMoveUp = Boolean(onReorder && position && position.index > 0);
+  const canMoveDown = Boolean(
+    onReorder && position && position.index < position.count - 1,
+  );
 
   return (
     <article className="group relative">
@@ -65,6 +77,16 @@ export function TaskCard({
             label={`Actions for ${task.title}`}
             triggerClassName="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-dim)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
           >
+            {canMoveUp ? (
+              <MenuItem onSelect={() => onReorder!(task, "up")}>
+                Move up
+              </MenuItem>
+            ) : null}
+            {canMoveDown ? (
+              <MenuItem onSelect={() => onReorder!(task, "down")}>
+                Move down
+              </MenuItem>
+            ) : null}
             {onMove
               ? moveTargets.map((column) => (
                   <MenuItem

--- a/components/board/TaskModal.test.tsx
+++ b/components/board/TaskModal.test.tsx
@@ -17,6 +17,7 @@ const task: TaskDTO = {
   title: "Ship the modal",
   description: "Interactive task details with subtask progress.",
   status: { name: "doing", color: "" },
+  order: 0,
   subtasks: [
     { id: "s1", title: "Markup", completed: true },
     { id: "s2", title: "Styles", completed: false },

--- a/components/board/a11y.test.tsx
+++ b/components/board/a11y.test.tsx
@@ -34,6 +34,7 @@ const task: TaskDTO = {
   title: "Ship the accessibility pass",
   description: "Make the board usable by keyboard and screen readers.",
   status: { name: "todo", color: "" },
+  order: 0,
   subtasks: [
     { id: "s1", title: "Overlay stack", completed: true },
     { id: "s2", title: "Card actions menu", completed: false },
@@ -46,7 +47,9 @@ function renderCard() {
       task={task}
       onOpen={() => {}}
       columns={columns}
+      position={{ index: 1, count: 3 }}
       onMove={() => {}}
+      onReorder={() => {}}
       onEdit={() => {}}
       onDelete={() => {}}
     />,

--- a/components/ui/Logo.tsx
+++ b/components/ui/Logo.tsx
@@ -1,0 +1,40 @@
+// The kboards brand mark: three rounded columns of varying height, evoking a
+// kanban board's columns at different fill levels. Kept as inline SVG (not an
+// <img>) so it inherits crisp rendering at any size and needs no network fetch.
+// The same three-column glyph is reused for the favicon, apple-touch icon, and
+// social image so the brand reads consistently across surfaces.
+export function LogoMark({
+  className,
+  title,
+}: {
+  className?: string;
+  // When set, the mark is announced to assistive tech; omit it where an adjacent
+  // "kboards" wordmark already names the brand, so it stays decorative.
+  title?: string;
+}) {
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      className={className}
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
+    >
+      {title ? <title>{title}</title> : null}
+      <rect x="4" y="6" width="7" height="20" rx="2.5" fill="#635fc7" />
+      <rect x="12.5" y="6" width="7" height="13" rx="2.5" fill="#49c4e5" />
+      <rect x="21" y="6" width="7" height="16" rx="2.5" fill="#67e2ae" />
+    </svg>
+  );
+}
+
+// The mark paired with the wordmark, used in the landing hero and app header.
+export function Logo({ className }: { className?: string }) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <LogoMark className="h-7 w-7" />
+      <span className="text-xl font-bold tracking-tight text-[var(--color-fg)]">
+        kboards
+      </span>
+    </span>
+  );
+}

--- a/lib/board/optimistic.test.ts
+++ b/lib/board/optimistic.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import type { BoardDTO } from "@/lib/dto";
-import { withMovedTask, withToggledSubtask } from "./optimistic";
+import {
+  withMovedTask,
+  withReorderedColumn,
+  withToggledSubtask,
+} from "./optimistic";
 
 function makeBoard(): BoardDTO {
   return {
@@ -15,6 +19,7 @@ function makeBoard(): BoardDTO {
         id: "t1",
         title: "Build it",
         status: { name: "todo", color: "" },
+        order: 0,
         subtasks: [
           { id: "s1", title: "Plan", completed: false },
           { id: "s2", title: "Ship", completed: true },
@@ -24,6 +29,14 @@ function makeBoard(): BoardDTO {
         id: "t2",
         title: "Test it",
         status: { name: "doing", color: "" },
+        order: 0,
+        subtasks: [],
+      },
+      {
+        id: "t3",
+        title: "Refine it",
+        status: { name: "todo", color: "" },
+        order: 1,
         subtasks: [],
       },
     ],
@@ -44,6 +57,8 @@ describe("withMovedTask", () => {
     expect(next.tasks.find((task) => task.id === "t2")?.status.name).toBe(
       "doing",
     );
+    // The moved task lands at the bottom of the destination column (after t2).
+    expect(moved?.order).toBe(1);
   });
 
   it("does not mutate the input board", () => {
@@ -51,6 +66,38 @@ describe("withMovedTask", () => {
     withMovedTask(board, "t1", "doing");
 
     expect(board.tasks[0].status.name).toBe("todo");
+  });
+});
+
+describe("withReorderedColumn", () => {
+  it("renumbers the listed tasks to their index in the new order", () => {
+    const board = makeBoard();
+    // Put t3 before t1 within "todo".
+    const next = withReorderedColumn(board, "todo", ["t3", "t1"]);
+
+    expect(next.tasks.find((task) => task.id === "t3")?.order).toBe(0);
+    expect(next.tasks.find((task) => task.id === "t1")?.order).toBe(1);
+    // A task in another column is left alone.
+    expect(next.tasks.find((task) => task.id === "t2")?.order).toBe(0);
+  });
+
+  it("snaps a task from another column into the target column with its color", () => {
+    const board = makeBoard();
+    board.columns[0].color = "#67e2ae"; // the "todo" column we drop into
+    // Drop t2 (from "doing") between t1 and t3 in "todo".
+    const next = withReorderedColumn(board, "todo", ["t1", "t2", "t3"]);
+
+    const moved = next.tasks.find((task) => task.id === "t2");
+    expect(moved?.status.name).toBe("todo");
+    expect(moved?.status.color).toBe("#67e2ae");
+    expect(moved?.order).toBe(1);
+  });
+
+  it("does not mutate the input board", () => {
+    const board = makeBoard();
+    withReorderedColumn(board, "todo", ["t3", "t1"]);
+
+    expect(board.tasks.find((task) => task.id === "t1")?.order).toBe(0);
   });
 });
 

--- a/lib/board/optimistic.ts
+++ b/lib/board/optimistic.ts
@@ -18,12 +18,21 @@ export function withMovedTask(
   const targetColumn = board.columns.find(
     (column) => column.name === toColumnName,
   );
+  // Append to the bottom of the destination column, matching the server, so the
+  // moved card lands last instead of wherever its old column order placed it.
+  // max(order)+1 (not a count) stays collision-free when the column's orders
+  // have a gap from an earlier cross-column move.
+  const destOrders = board.tasks
+    .filter((task) => task.status.name === toColumnName && task.id !== taskId)
+    .map((task) => task.order);
+  const endOrder = destOrders.length ? Math.max(...destOrders) + 1 : 0;
   return {
     ...board,
     tasks: board.tasks.map((task) =>
       task.id === taskId
         ? {
             ...task,
+            order: endOrder,
             status: {
               name: toColumnName,
               color: targetColumn?.color ?? task.status.color,
@@ -31,6 +40,36 @@ export function withMovedTask(
           }
         : task,
     ),
+  };
+}
+
+// Apply a new within-column ordering optimistically. `orderedTaskIds` is the
+// target column's full desired order; each listed task is renumbered to its
+// index and snapped into that column (so this covers both reordering and a
+// cross-column drop), mirroring the reorder service.
+export function withReorderedColumn(
+  board: BoardDTO,
+  columnName: string,
+  orderedTaskIds: string[],
+): BoardDTO {
+  const targetColumn = board.columns.find(
+    (column) => column.name === columnName,
+  );
+  const indexById = new Map(orderedTaskIds.map((id, index) => [id, index]));
+  return {
+    ...board,
+    tasks: board.tasks.map((task) => {
+      const index = indexById.get(task.id);
+      if (index === undefined) return task;
+      return {
+        ...task,
+        order: index,
+        status: {
+          name: columnName,
+          color: targetColumn?.color ?? task.status.color,
+        },
+      };
+    }),
   };
 }
 

--- a/lib/db/models/Board.ts
+++ b/lib/db/models/Board.ts
@@ -26,6 +26,11 @@ export interface ITask {
   title: string;
   description?: string;
   status: IStatus;
+  // Position of the task within its column, ascending. Tasks are stored in one
+  // flat array regardless of column, so ordering is by this field scoped to the
+  // task's status; ties (e.g. legacy tasks that predate the field, all 0) fall
+  // back to array order via a stable sort.
+  order: number;
   subtasks: Types.DocumentArray<ISubtask>;
 }
 
@@ -60,6 +65,7 @@ const TaskSchema = new Schema<ITask>(
     title: { type: String, required: [true, "Title is required"] },
     description: { type: String },
     status: { type: StatusSchema, required: true },
+    order: { type: Number, default: 0 },
     subtasks: { type: [SubtaskSchema], default: [] },
   },
   { timestamps: true },

--- a/lib/dto.test.ts
+++ b/lib/dto.test.ts
@@ -55,6 +55,26 @@ describe("toBoard", () => {
     ]);
   });
 
+  it("emits tasks sorted by their in-column order", () => {
+    const board = new Board({
+      createdBy: new Types.ObjectId(),
+      name: "Ordered",
+      columns: [{ name: "todo", color: "default" }],
+      // Stored out of order; the DTO should sort them ascending by `order`.
+      tasks: [
+        { title: "Third", status: { name: "todo" }, order: 2, subtasks: [] },
+        { title: "First", status: { name: "todo" }, order: 0, subtasks: [] },
+        { title: "Second", status: { name: "todo" }, order: 1, subtasks: [] },
+      ],
+    });
+
+    expect(toBoard(board).tasks.map((task) => task.title)).toEqual([
+      "First",
+      "Second",
+      "Third",
+    ]);
+  });
+
   it("omits an absent description rather than emitting null", () => {
     const board = new Board({
       createdBy: new Types.ObjectId(),

--- a/lib/dto.ts
+++ b/lib/dto.ts
@@ -15,6 +15,9 @@ export interface TaskDTO {
   title: string;
   description?: string;
   status: { name: string; color: string };
+  // Position within the task's column, ascending. The UI sorts each column by
+  // this so reordering survives a round-trip.
+  order: number;
   subtasks: SubtaskDTO[];
 }
 
@@ -55,16 +58,21 @@ export function toBoard(board: BoardDocument): BoardDTO {
       name: column.name,
       color: column.color,
     })),
-    tasks: board.tasks.map((task) => ({
-      id: String(task._id),
-      title: task.title,
-      ...(task.description != null ? { description: task.description } : {}),
-      status: { name: task.status.name, color: task.status.color ?? "" },
-      subtasks: task.subtasks.map((subtask) => ({
-        id: String(subtask._id),
-        title: subtask.title,
-        completed: subtask.completed,
+    // Emit tasks pre-sorted by their in-column position. The sort is stable, so
+    // legacy tasks that share order 0 keep their stored array order.
+    tasks: [...board.tasks]
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+      .map((task) => ({
+        id: String(task._id),
+        title: task.title,
+        ...(task.description != null ? { description: task.description } : {}),
+        status: { name: task.status.name, color: task.status.color ?? "" },
+        order: task.order ?? 0,
+        subtasks: task.subtasks.map((subtask) => ({
+          id: String(subtask._id),
+          title: subtask.title,
+          completed: subtask.completed,
+        })),
       })),
-    })),
   };
 }

--- a/lib/services/tasks.test.ts
+++ b/lib/services/tasks.test.ts
@@ -10,6 +10,7 @@ import {
   updateTask,
   updateSubtask,
   deleteTask,
+  reorderColumn,
 } from "@/lib/services/tasks";
 
 const newId = () => new mongoose.Types.ObjectId().toString();
@@ -69,6 +70,61 @@ describe("createTask", () => {
       "open PR",
     ]);
     expect(task.subtasks.every((s) => s.completed === false)).toBe(true);
+  });
+
+  it("assigns each new task the next order within its column", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+
+    let board = await createTask(userId, boardId, {
+      title: "First",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    expect(lastTask(board).order).toBe(0);
+
+    board = await createTask(userId, boardId, {
+      title: "Second",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    expect(lastTask(board).order).toBe(1);
+
+    // A different column starts its own numbering.
+    board = await createTask(userId, boardId, {
+      title: "Elsewhere",
+      status: { name: "doing" },
+      subtasks: [],
+    });
+    expect(lastTask(board).order).toBe(0);
+  });
+
+  it("gives a new task an order past a gap left by a cross-column move", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const ids: string[] = [];
+    for (const title of ["A", "B", "C"]) {
+      const board = await createTask(userId, boardId, {
+        title,
+        status: { name: "todo" },
+        subtasks: [],
+      });
+      ids.push(String(lastTask(board)._id));
+    }
+    // Move B out to "doing", leaving "todo" with orders [0 (A), 2 (C)] — a gap.
+    await reorderColumn(userId, boardId, {
+      columnName: "doing",
+      orderedTaskIds: [ids[1]],
+    });
+
+    const board = await createTask(userId, boardId, {
+      title: "D",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+
+    // max(order)+1 = 3, not the count (2) which would collide with C's order.
+    expect(lastTask(board).order).toBe(3);
   });
 
   it("stores the column's canonical name regardless of input casing", async () => {
@@ -153,6 +209,35 @@ describe("updateTask", () => {
     ).toBe(400);
   });
 
+  it("appends the task to the bottom of the destination column when moved", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    // Two tasks already sit in "doing" (orders 0 and 1).
+    await createTask(userId, boardId, {
+      title: "Doing A",
+      status: { name: "doing" },
+      subtasks: [],
+    });
+    await createTask(userId, boardId, {
+      title: "Doing B",
+      status: { name: "doing" },
+      subtasks: [],
+    });
+    let board = await createTask(userId, boardId, {
+      title: "Mover",
+      status: { name: "todo" },
+      subtasks: [],
+    });
+    const taskId = String(lastTask(board)._id);
+
+    board = await updateTask(userId, boardId, taskId, {
+      status: { name: "doing" },
+    });
+
+    // Lands after the two existing "doing" tasks rather than keeping order 0.
+    expect(board.tasks.id(taskId)!.order).toBe(2);
+  });
+
   it("404s a missing task", async () => {
     const userId = newId();
     const { boardId } = await boardWithColumns(userId);
@@ -160,6 +245,118 @@ describe("updateTask", () => {
     expect(
       await rejectionStatus(
         updateTask(userId, boardId, newId(), { title: "x" }),
+      ),
+    ).toBe(404);
+  });
+});
+
+describe("reorderColumn", () => {
+  // Seeds three tasks in "todo" and returns their ids in creation order.
+  async function threeInTodo(userId: string, boardId: string) {
+    const ids: string[] = [];
+    for (const title of ["A", "B", "C"]) {
+      const board = await createTask(userId, boardId, {
+        title,
+        status: { name: "todo" },
+        subtasks: [],
+      });
+      ids.push(String(lastTask(board)._id));
+    }
+    return ids;
+  }
+
+  it("renumbers the column's tasks to the given order", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const [a, b, c] = await threeInTodo(userId, boardId);
+
+    const board = await reorderColumn(userId, boardId, {
+      columnName: "todo",
+      orderedTaskIds: [c, a, b],
+    });
+
+    expect(board.tasks.id(c)!.order).toBe(0);
+    expect(board.tasks.id(a)!.order).toBe(1);
+    expect(board.tasks.id(b)!.order).toBe(2);
+  });
+
+  it("moves a task into the column at the requested position", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const [a, b, c] = await threeInTodo(userId, boardId);
+    let board = await createTask(userId, boardId, {
+      title: "FromDoing",
+      status: { name: "doing" },
+      subtasks: [],
+    });
+    const moved = String(lastTask(board)._id);
+
+    // Drop the "doing" task between A and B.
+    board = await reorderColumn(userId, boardId, {
+      columnName: "todo",
+      orderedTaskIds: [a, moved, b, c],
+    });
+
+    const task = board.tasks.id(moved)!;
+    expect(task.status.name).toBe("todo");
+    expect(task.order).toBe(1);
+    expect(board.tasks.id(b)!.order).toBe(2);
+  });
+
+  it("resolves the column name case-insensitively to its canonical form", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const [a] = await threeInTodo(userId, boardId);
+
+    const board = await reorderColumn(userId, boardId, {
+      columnName: "TODO",
+      orderedTaskIds: [a],
+    });
+
+    expect(board.tasks.id(a)!.status.name).toBe("todo");
+  });
+
+  it("rejects an unknown task id", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const [a] = await threeInTodo(userId, boardId);
+
+    expect(
+      await rejectionStatus(
+        reorderColumn(userId, boardId, {
+          columnName: "todo",
+          orderedTaskIds: [a, newId()],
+        }),
+      ),
+    ).toBe(400);
+  });
+
+  it("rejects a column that is not on the board", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const [a] = await threeInTodo(userId, boardId);
+
+    expect(
+      await rejectionStatus(
+        reorderColumn(userId, boardId, {
+          columnName: "ghost",
+          orderedTaskIds: [a],
+        }),
+      ),
+    ).toBe(400);
+  });
+
+  it("404s when the board does not belong to the user", async () => {
+    const userId = newId();
+    const { boardId } = await boardWithColumns(userId);
+    const [a] = await threeInTodo(userId, boardId);
+
+    expect(
+      await rejectionStatus(
+        reorderColumn(newId(), boardId, {
+          columnName: "todo",
+          orderedTaskIds: [a],
+        }),
       ),
     ).toBe(404);
   });

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -1,4 +1,4 @@
-import { isValidObjectId } from "mongoose";
+import { isValidObjectId, type Types } from "mongoose";
 import { dbConnect } from "@/lib/db/mongoose";
 import type { IStatus } from "@/lib/db/models/Board";
 import { badRequest, notFound } from "./errors";
@@ -16,6 +16,24 @@ function resolveStatusName(board: BoardDocument, status: IStatus): string {
   return column.name;
 }
 
+// The order to give a task appended to the bottom of `columnName`: one past the
+// current maximum, or 0 for an empty column. Optionally ignore one task (used
+// when moving a task into a column it should be placed after).
+function nextOrder(
+  board: BoardDocument,
+  columnName: string,
+  ignoreTaskId?: Types.ObjectId,
+): number {
+  const orders = board.tasks
+    .filter(
+      (task) =>
+        task.status.name === columnName &&
+        !(ignoreTaskId && task._id?.equals(ignoreTaskId)),
+    )
+    .map((task) => task.order ?? 0);
+  return orders.length ? Math.max(...orders) + 1 : 0;
+}
+
 export async function createTask(
   userId: string,
   boardId: string,
@@ -30,13 +48,48 @@ export async function createTask(
   const board = await findOwnedBoard(userId, boardId);
   const statusName = resolveStatusName(board, input.status);
 
+  // New tasks land at the bottom of their column. Use max(order)+1 rather than a
+  // count so a column with non-contiguous orders (a gap left by a cross-column
+  // move) never reuses an order value already present.
+  const order = nextOrder(board, statusName);
+
   const task = board.tasks.create({
     title: input.title,
     status: { name: statusName, color: input.status.color },
+    order,
     description: input.description,
     subtasks: input.subtasks.map((title) => ({ title, completed: false })),
   });
   board.tasks.push(task);
+
+  await board.save();
+  return board;
+}
+
+// Applies a new within-column order. `orderedTaskIds` is the target column's
+// full desired ordering; each listed task is renumbered to its index and, if it
+// lived in another column, moved into this one. This one operation covers both
+// reordering within a column and dropping a card into a column at a position.
+export async function reorderColumn(
+  userId: string,
+  boardId: string,
+  input: { columnName: string; orderedTaskIds: string[] },
+): Promise<BoardDocument> {
+  await dbConnect();
+  const board = await findOwnedBoard(userId, boardId);
+
+  // Canonical column name (and its color) so the moved tasks' status snapshots
+  // match the column exactly, as elsewhere in the service.
+  const columnName = resolveStatusName(board, { name: input.columnName });
+  const column = board.columns.find((col) => col.name === columnName);
+
+  input.orderedTaskIds.forEach((taskId, index) => {
+    if (!isValidObjectId(taskId)) throw badRequest("Unknown task in reorder");
+    const task = board.tasks.id(taskId);
+    if (!task) throw badRequest("Unknown task in reorder");
+    task.order = index;
+    task.status = { name: columnName, color: column?.color };
+  });
 
   await board.save();
   return board;
@@ -67,6 +120,12 @@ export async function updateTask(
   if (input.title !== undefined) task.title = input.title;
   if (input.description !== undefined) task.description = input.description;
   if (input.status !== undefined && statusName !== null) {
+    // Moving to a different column appends the task to the bottom of that
+    // column (matching new-task placement), so it never inherits a stale order
+    // from its old column and sort into the middle of the destination.
+    if (statusName !== task.status.name) {
+      task.order = nextOrder(board, statusName, task._id);
+    }
     task.status = { name: statusName, color: input.status.color };
   }
 

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { taskReorderSchema } from "./validation";
+
+describe("taskReorderSchema", () => {
+  it("accepts a column name and a list of unique task ids", () => {
+    const result = taskReorderSchema.safeParse({
+      columnName: "todo",
+      orderedTaskIds: ["a", "b", "c"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects duplicate ids, which would collide orders in the service", () => {
+    const result = taskReorderSchema.safeParse({
+      columnName: "todo",
+      orderedTaskIds: ["a", "b", "a"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty order list", () => {
+    const result = taskReorderSchema.safeParse({
+      columnName: "todo",
+      orderedTaskIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -75,6 +75,21 @@ export const taskUpdateSchema = z
     message: "Provide at least one field to update",
   });
 
+// Reordering sends the target column's full desired task order. The server
+// renumbers those tasks and moves any into the column, so within-column
+// reordering and cross-column drop-at-position share one idempotent operation.
+export const taskReorderSchema = z.object({
+  columnName: z.string().min(1),
+  // Reject duplicate ids: the service assigns `order = index` per entry, so a
+  // repeated id would silently collide orders and leave the column half-numbered.
+  orderedTaskIds: z
+    .array(z.string().min(1))
+    .min(1)
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: "orderedTaskIds must not contain duplicates",
+    }),
+});
+
 export const subtaskUpdateSchema = z
   .object({
     title: z.string().min(1).optional(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kboards",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Promotes `develop` to production (`main`) for the **v2.1.0** release.

**Contents** (merged to develop via #20):
- Within-column task reordering (drag + accessible Move up/down), `order` field on the embedded task model, idempotent `PATCH /tasks/reorder`.
- Brand identity: logo mark, favicon, apple-touch icon, `next/og` OG/Twitter image, web manifest, metadata.
- Style polish (accent glow, themed scrollbars).
- CodeRabbit fix: reject duplicate ids in the reorder payload.

111 tests pass; typecheck, lint, build green; verified end-to-end in a browser. Tag `v2.1.0` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop task reordering within columns, including dropping at a specific position across columns.
  * Added keyboard/screen-reader controls to move tasks up or down from the task menu.
  * Refreshed branding across the app with a new logo, icons, and social preview image.

* **Bug Fixes**
  * Improved task ordering so items stay in the correct place after moves and refreshes.
  * Enhanced visual polish with themed scrollbars and a subtle background glow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->