### PR TITLE
feat(growth): launch activation sprint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,12 +10,13 @@ AUTH_SECRET=
 # or reset links and auth redirects will point at the wrong host.
 AUTH_URL=http://localhost:3000
 
-# Transactional email for password resets. Leave SMTP_HOST empty in dev to log
-# the reset link to the console instead of sending mail. For production these
-# can be Resend: SMTP_HOST=smtp.resend.com, SMTP_PORT=465, SMTP_USER=resend,
-# SMTP_PASS=<your Resend API key>.
+# Transactional email for password resets. Leave RESEND_API_KEY empty in dev to
+# log the reset link to the console instead of sending mail.
 EMAIL_FROM=
+RESEND_API_KEY=
+
+# Temporary compatibility with the previous Resend SMTP deployment. When
+# SMTP_HOST is smtp.resend.com, SMTP_PASS is accepted as the API key. Migrate
+# Vercel to RESEND_API_KEY, then remove these legacy values.
 SMTP_HOST=
-SMTP_PORT=
-SMTP_USER=
 SMTP_PASS=

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ npm-debug.log*
 next-env.d.ts
 .vercel
 *.tsbuildinfo
+.playwright-cli
+output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.1.0] - 2026-07-02
+### Added
+
+- Product-led landing experience centered on an interactive three-column board
+  preview, clearer personal-productivity positioning, and direct first-use calls
+  to action.
+- Optional Personal-flow board template with Backlog, This week, and Done
+  columns plus editable starter prompts; existing API clients continue to create
+  blank boards by default.
+- Privacy-redacted Vercel Web Analytics integration. Board identifiers,
+  password-reset credentials, and query parameters are removed before page-view
+  events are sent.
+
+### Changed
+
+- Updated Next.js, Auth.js, Tailwind/PostCSS, Sharp, and related dependencies to
+  patched compatible releases; removed the unused Auth MongoDB adapter.
+- Replaced Nodemailer/SMTP delivery with Resend’s HTTPS Email API, retaining a
+  temporary compatibility path for the current Resend SMTP environment values.
+
+## [2.1.0] - 2026-07-27
 
 A polish-and-feature release: task cards can now be reordered within a column, and the app
 gains a real brand identity (logo mark, favicon, and social share image).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ iteration" portfolio project. The rebuild is tracked visibly through commits, AD
 - **Authentication** — email/password (Auth.js v5, Credentials + JWT sessions) with a custom
   password-reset flow whose tokens are stored only as SHA-256 hashes and are single-use.
 - **Responsive** — a board-list sidebar that becomes a slide-over drawer on small screens.
+- **Fast first board** — start blank or choose a Personal flow with Backlog, This week, and Done
+  columns plus editable prompts.
+- **Product-led preview** — visitors can move a task through a real interactive board preview
+  before creating an account.
 
 ## Tech stack
 
@@ -37,7 +41,8 @@ iteration" portfolio project. The rebuild is tracked visibly through commits, AD
 | Data | MongoDB via Mongoose 9 (embedded board document model) |
 | Auth | Auth.js v5 (`next-auth`), Credentials provider, JWT sessions |
 | Validation | zod |
-| Email | nodemailer (SMTP; Resend in production) |
+| Email | Resend Email API |
+| Analytics | Vercel Web Analytics with sensitive-route redaction |
 | Tests | Vitest + Testing Library + jsdom, axe-core |
 | Hosting | Vercel + MongoDB Atlas |
 
@@ -112,8 +117,16 @@ JWT, so no session store is required. Set these environment variables in the Ver
 | `MONGODB_URI` | Atlas SRV string, with the `/kboards` database name |
 | `AUTH_SECRET` | `openssl rand -base64 32` |
 | `AUTH_URL` | The deployed origin, e.g. `https://kboards.vercel.app` |
-| `EMAIL_FROM` | Sender for reset emails |
-| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` | Resend: `smtp.resend.com` / `465` / `resend` / _API key_ |
+| `EMAIL_FROM` | Verified sender for reset emails |
+| `RESEND_API_KEY` | Resend API key; leave empty locally to log reset links |
+
+Enable Web Analytics from the Vercel project’s **Analytics** page before deploying the analytics
+integration. Page views are anonymous; kboards strips board ids, password-reset links, and query
+parameters in `beforeSend`.
+
+The email sender temporarily accepts the existing Resend SMTP configuration
+(`SMTP_HOST=smtp.resend.com` plus `SMTP_PASS`) as a compatibility fallback. Move the same API key to
+`RESEND_API_KEY` in Vercel; no immediate production cutover is required.
 
 ## Author
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,6 +33,17 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+.landing-shell {
+  background:
+    linear-gradient(180deg, transparent 0%, rgba(8, 10, 14, 0.45) 100%),
+    repeating-linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(25% - 1px),
+      rgba(255, 255, 255, 0.025) 25%
+    );
+}
+
 ::selection {
   background: color-mix(in srgb, var(--color-accent) 40%, transparent);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
+import { WebAnalytics } from "@/components/analytics/WebAnalytics";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://kboards.jeramiahcoffey.com";
 
@@ -42,6 +43,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <Providers>{children}</Providers>
+        <WebAnalytics />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,36 +1,126 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
-import { LogoMark } from "@/components/ui/Logo";
+import { InteractiveBoardPreview } from "@/components/landing/InteractiveBoardPreview";
+import { Logo } from "@/components/ui/Logo";
+
+const PRINCIPLES = [
+  {
+    title: "Capture without clutter",
+    copy: "Keep ideas in view without turning every thought into a commitment.",
+  },
+  {
+    title: "Choose what moves",
+    copy: "A small Today column makes the current promise obvious.",
+  },
+  {
+    title: "Finish accessibly",
+    copy: "Pointer, keyboard, and screen-reader users get equivalent ways to move work.",
+  },
+] as const;
 
 export default async function Home() {
   if (await auth()) redirect("/boards");
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col justify-center gap-6 px-6">
-      <div className="flex items-center gap-3">
-        <LogoMark className="h-9 w-9" title="kboards" />
-        <h1 className="text-3xl font-bold tracking-tight">kboards</h1>
-      </div>
-      <p className="max-w-prose text-lg text-[var(--color-dim)]">
-        A kanban board for tracking work. Create boards, organize tasks into
-        columns, break work into subtasks, and drag to reorder as priorities
-        shift.
-      </p>
-      <div className="flex flex-wrap gap-3">
-        <Link
-          href="/register"
-          className="inline-flex min-h-11 items-center justify-center rounded-full bg-[var(--color-accent)] px-5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-accent-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
-        >
-          Get started
-        </Link>
+    <div className="landing-shell min-h-dvh">
+      <header className="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-5 sm:px-8 lg:px-10">
+        <Logo />
         <Link
           href="/login"
-          className="inline-flex min-h-11 items-center justify-center rounded-full bg-[var(--color-surface-2)] px-5 text-sm font-semibold text-[var(--color-fg)] transition-colors hover:bg-[var(--color-line)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+          className="rounded-full px-4 py-2 text-sm font-semibold text-[var(--color-dim)] transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
         >
           Sign in
         </Link>
-      </div>
-    </main>
+      </header>
+
+      <main>
+        <section className="mx-auto grid w-full max-w-7xl items-center gap-12 px-5 pb-20 pt-12 sm:px-8 sm:pt-20 lg:grid-cols-[0.82fr_1.18fr] lg:gap-16 lg:px-10 lg:pb-28 lg:pt-24">
+          <div className="max-w-xl">
+            <p className="mb-5 text-xs font-bold uppercase tracking-[0.22em] text-[#77d8ee]">
+              Your work, without the workspace
+            </p>
+            <h1 className="text-balance text-[clamp(3.5rem,8vw,6.8rem)] font-black leading-[0.86] tracking-[-0.075em] text-white">
+              Keep the week moving.
+            </h1>
+            <p className="mt-7 max-w-lg text-pretty text-lg leading-8 text-[var(--color-dim)]">
+              A focused personal board for deciding what matters now, moving it
+              forward, and seeing what you actually finished.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/register"
+                className="inline-flex min-h-12 items-center justify-center rounded-full bg-[var(--color-accent)] px-6 text-sm font-bold text-white transition hover:-translate-y-0.5 hover:bg-[var(--color-accent-hover)] hover:text-[#11131a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-hover)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+              >
+                Start a personal board
+              </Link>
+              <a
+                href="#try-the-board"
+                className="inline-flex min-h-12 items-center justify-center rounded-full border border-[var(--color-line)] px-6 text-sm font-bold text-[var(--color-fg)] transition-colors hover:border-[var(--color-dim)] hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              >
+                Try it first
+              </a>
+            </div>
+            <p className="mt-4 text-xs text-[var(--color-dim)]">
+              Free to use · No team setup · Built for keyboard access
+            </p>
+          </div>
+
+          <div id="try-the-board" className="scroll-mt-8">
+            <InteractiveBoardPreview />
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.07] bg-black/10">
+          <div className="mx-auto grid w-full max-w-7xl divide-y divide-white/[0.07] px-5 sm:px-8 lg:grid-cols-3 lg:divide-x lg:divide-y-0 lg:px-10">
+            {PRINCIPLES.map((principle, index) => (
+              <article
+                key={principle.title}
+                className="py-8 first:lg:pr-8 lg:px-8 lg:py-10 last:lg:pr-0"
+              >
+                <p className="text-[0.65rem] font-bold uppercase tracking-[0.2em] text-[var(--color-dim)]">
+                  {String(index + 1).padStart(2, "0")}
+                </p>
+                <h2 className="mt-4 text-lg font-bold text-white">
+                  {principle.title}
+                </h2>
+                <p className="mt-2 max-w-sm text-sm leading-6 text-[var(--color-dim)]">
+                  {principle.copy}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="mx-auto flex w-full max-w-4xl flex-col items-center px-5 py-24 text-center sm:px-8 sm:py-32">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#82e7b8]">
+            Start with a board that already makes sense
+          </p>
+          <h2 className="mt-5 text-balance text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">
+            Less setup. More finished.
+          </h2>
+          <p className="mt-5 max-w-xl text-pretty text-base leading-7 text-[var(--color-dim)]">
+            Your first board can open with a calm Backlog → This week → Done
+            flow and a few prompts you can edit or delete.
+          </p>
+          <Link
+            href="/register"
+            className="mt-8 inline-flex min-h-12 items-center justify-center rounded-full bg-white px-7 text-sm font-bold text-[#11131a] transition hover:-translate-y-0.5 hover:bg-[#dce0e8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+          >
+            Create your board
+          </Link>
+        </section>
+      </main>
+
+      <footer className="mx-auto flex w-full max-w-7xl flex-col gap-4 border-t border-white/[0.07] px-5 py-7 text-xs text-[var(--color-dim)] sm:flex-row sm:items-center sm:justify-between sm:px-8 lg:px-10">
+        <span>kboards · A calmer way to track personal work.</span>
+        <a
+          href="https://github.com/jeramiahgcoffey/kboards"
+          className="w-fit font-semibold transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+        >
+          Built in the open on GitHub ↗
+        </a>
+      </footer>
+    </div>
   );
 }

--- a/components/analytics/WebAnalytics.tsx
+++ b/components/analytics/WebAnalytics.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { Analytics } from "@vercel/analytics/next";
+import { redactAnalyticsRoute } from "@/lib/analytics";
+
+// Keep the callback on the client side: Next.js cannot serialize a function
+// prop from the server RootLayout into the Analytics client component.
+export function WebAnalytics() {
+  return <Analytics beforeSend={redactAnalyticsRoute} />;
+}

--- a/components/board/BoardFormModal.test.tsx
+++ b/components/board/BoardFormModal.test.tsx
@@ -39,6 +39,7 @@ describe("BoardFormModal", () => {
     expect(onSubmit).toHaveBeenCalledWith({
       name: "Platform Launch",
       description: undefined,
+      template: "personal",
     });
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });
@@ -56,5 +57,27 @@ describe("BoardFormModal", () => {
     expect(screen.getByRole("dialog", { name: /edit board/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/board name/i)).toHaveValue("Roadmap");
     expect(screen.getByLabelText(/description/i)).toHaveValue("Long term plan");
+    expect(
+      screen.queryByRole("group", { name: /starting layout/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("can create a blank board", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(true);
+    render(
+      <BoardFormModal mode="create" onSubmit={onSubmit} onClose={vi.fn()} />,
+    );
+
+    await userEvent.type(screen.getByLabelText(/board name/i), "Scratch");
+    await userEvent.click(screen.getByRole("radio", { name: /blank board/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /create board/i }),
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: "Scratch",
+      description: undefined,
+      template: "blank",
+    });
   });
 });

--- a/components/board/BoardFormModal.tsx
+++ b/components/board/BoardFormModal.tsx
@@ -5,10 +5,12 @@ import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
 import { TextField } from "@/components/ui/TextField";
 import { TextArea } from "@/components/ui/TextArea";
+import type { BoardTemplateId } from "@/lib/board/templates";
 
 export interface BoardFormValues {
   name: string;
   description?: string;
+  template?: BoardTemplateId;
 }
 
 interface BoardFormModalProps {
@@ -31,6 +33,7 @@ export function BoardFormModal({
   const titleId = useId();
   const [name, setName] = useState(initial?.name ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
+  const [template, setTemplate] = useState<BoardTemplateId>("personal");
   const [errors, setErrors] = useState<{ name?: string; description?: string }>(
     {},
   );
@@ -60,6 +63,7 @@ export function BoardFormModal({
     const ok = await onSubmit({
       name: trimmedName,
       description: trimmedDescription || undefined,
+      ...(mode === "create" ? { template } : {}),
     });
     if (ok) {
       onClose();
@@ -91,6 +95,62 @@ export function BoardFormModal({
           maxLength={100}
           placeholder="What is this board for?"
         />
+        {mode === "create" ? (
+          <fieldset className="flex flex-col gap-2">
+            <legend className="mb-1 text-sm font-bold text-[var(--color-fg)]">
+              Starting layout
+            </legend>
+            <label
+              className={`cursor-pointer rounded-xl border p-4 transition-colors ${
+                template === "personal"
+                  ? "border-[var(--color-accent)] bg-[var(--color-accent)]/10"
+                  : "border-[var(--color-line)] hover:border-[var(--color-dim)]"
+              }`}
+            >
+              <span className="flex items-start gap-3">
+                <input
+                  type="radio"
+                  name="template"
+                  value="personal"
+                  checked={template === "personal"}
+                  onChange={() => setTemplate("personal")}
+                  className="mt-1 accent-[var(--color-accent)]"
+                />
+                <span>
+                  <span className="block text-sm font-bold">Personal flow</span>
+                  <span className="mt-1 block text-xs leading-5 text-[var(--color-dim)]">
+                    Backlog, This week, and Done—with editable prompts to get
+                    moving.
+                  </span>
+                </span>
+              </span>
+            </label>
+            <label
+              className={`cursor-pointer rounded-xl border p-4 transition-colors ${
+                template === "blank"
+                  ? "border-[var(--color-accent)] bg-[var(--color-accent)]/10"
+                  : "border-[var(--color-line)] hover:border-[var(--color-dim)]"
+              }`}
+            >
+              <span className="flex items-start gap-3">
+                <input
+                  type="radio"
+                  name="template"
+                  value="blank"
+                  checked={template === "blank"}
+                  onChange={() => setTemplate("blank")}
+                  className="mt-1 accent-[var(--color-accent)]"
+                />
+                <span>
+                  <span className="block text-sm font-bold">Blank board</span>
+                  <span className="mt-1 block text-xs leading-5 text-[var(--color-dim)]">
+                    Start empty and choose every column yourself.
+                  </span>
+                </span>
+              </span>
+            </label>
+          </fieldset>
+        ) : null}
         <div className="flex flex-col-reverse gap-3 sm:flex-row">
           <Button
             type="button"

--- a/components/board/CreateBoardButton.tsx
+++ b/components/board/CreateBoardButton.tsx
@@ -15,9 +15,11 @@ import { BoardFormModal, type BoardFormValues } from "./BoardFormModal";
 export function CreateBoardButton({
   onCreated,
   variant = "sidebar",
+  label,
 }: {
   onCreated?: () => void;
   variant?: "sidebar" | "primary";
+  label?: string;
 }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -44,7 +46,7 @@ export function CreateBoardButton({
     <>
       {variant === "primary" ? (
         <Button type="button" onClick={() => setOpen(true)}>
-          + Create New Board
+          {label ?? "+ Create New Board"}
         </Button>
       ) : (
         <button

--- a/components/board/EmptyBoards.tsx
+++ b/components/board/EmptyBoards.tsx
@@ -4,12 +4,31 @@ import { CreateBoardButton } from "./CreateBoardButton";
 
 export function EmptyBoards() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-4 px-6 py-16 text-center">
-      <h2 className="text-xl font-bold tracking-tight">No boards yet</h2>
-      <p className="max-w-sm text-[var(--color-dim)]">
-        Create your first board to set up columns and start tracking tasks.
+    <div className="flex h-full flex-col items-center justify-center px-6 py-16 text-center">
+      <span
+        aria-hidden
+        className="mb-6 grid h-16 w-16 grid-cols-3 items-end gap-1.5 rounded-2xl border border-[var(--color-line)] bg-[var(--color-surface)] p-3"
+      >
+        <span className="h-8 rounded-sm bg-[#8471f2]" />
+        <span className="h-11 rounded-sm bg-[#49c4e5]" />
+        <span className="h-6 rounded-sm bg-[#67e2ae]" />
+      </span>
+      <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#77d8ee]">
+        Your first board
       </p>
-      <CreateBoardButton variant="primary" />
+      <h2 className="mt-3 text-3xl font-black tracking-[-0.04em]">
+        Start with a useful shape.
+      </h2>
+      <p className="mt-3 max-w-md leading-7 text-[var(--color-dim)]">
+        Choose the Personal flow for a ready-to-edit Backlog → This week → Done
+        board, or begin with a blank canvas.
+      </p>
+      <div className="mt-7">
+        <CreateBoardButton
+          variant="primary"
+          label="Create your first board"
+        />
+      </div>
     </div>
   );
 }

--- a/components/landing/InteractiveBoardPreview.test.tsx
+++ b/components/landing/InteractiveBoardPreview.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axe from "axe-core";
+import { InteractiveBoardPreview } from "./InteractiveBoardPreview";
+
+describe("InteractiveBoardPreview", () => {
+  it("lets a visitor move the highlighted task through the workflow", async () => {
+    render(<InteractiveBoardPreview />);
+
+    const task = screen.getByRole("button", {
+      name: /move ship the first version to done/i,
+    });
+    await userEvent.click(task);
+
+    expect(
+      screen.getByRole("button", {
+        name: /move ship the first version to later/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/ship the first version is now in done/i),
+    ).toBeInTheDocument();
+  });
+
+  it("has no detectable accessibility violations", async () => {
+    const { container } = render(<InteractiveBoardPreview />);
+    const { violations } = await axe.run(container, {
+      rules: { "color-contrast": { enabled: false } },
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/components/landing/InteractiveBoardPreview.tsx
+++ b/components/landing/InteractiveBoardPreview.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+const STAGES = [
+  { name: "Later", color: "#8471f2" },
+  { name: "Today", color: "#49c4e5" },
+  { name: "Done", color: "#67e2ae" },
+] as const;
+
+const SUPPORTING_TASKS = [
+  { title: "Choose the week’s focus", stage: 0 },
+  { title: "Write the launch note", stage: 1 },
+  { title: "Tell three real people", stage: 2 },
+] as const;
+
+const FOCUS_TASK = "Ship the first version";
+
+export function InteractiveBoardPreview() {
+  const [stage, setStage] = useState(1);
+
+  function advanceTask() {
+    setStage((current) => (current + 1) % STAGES.length);
+  }
+
+  const nextStage = STAGES[(stage + 1) % STAGES.length].name;
+
+  return (
+    <section
+      aria-label="Interactive kboards preview"
+      className="relative overflow-hidden rounded-[1.75rem] border border-white/10 bg-[#11141b] p-3 shadow-[0_32px_90px_rgba(0,0,0,0.45)] sm:p-5"
+    >
+      <div
+        aria-hidden
+        className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#49c4e5]/80 to-transparent"
+      />
+      <div className="mb-5 flex items-center justify-between gap-4 px-1">
+        <div>
+          <p className="text-[0.65rem] font-bold uppercase tracking-[0.22em] text-[var(--color-dim)]">
+            Personal board
+          </p>
+          <h2 className="mt-1 text-sm font-bold text-white">
+            Make this week count
+          </h2>
+        </div>
+        <span className="rounded-full border border-white/10 px-3 py-1 text-[0.65rem] font-semibold text-[var(--color-dim)]">
+          Try it
+        </span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 sm:gap-3">
+        {STAGES.map((column, columnIndex) => {
+          const supportingTask = SUPPORTING_TASKS.find(
+            (task) => task.stage === columnIndex,
+          );
+
+          return (
+            <div
+              key={column.name}
+              className="min-h-52 rounded-xl bg-white/[0.035] p-2 sm:min-h-64 sm:p-3"
+            >
+              <div className="mb-3 flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: column.color }}
+                />
+                <h3 className="truncate text-[0.58rem] font-bold uppercase tracking-[0.14em] text-[var(--color-dim)] sm:text-[0.65rem]">
+                  {column.name}
+                </h3>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                {stage === columnIndex ? (
+                  <button
+                    type="button"
+                    onClick={advanceTask}
+                    aria-label={`Move ${FOCUS_TASK} to ${nextStage}`}
+                    className="group min-h-24 rounded-lg border border-[#49c4e5]/40 bg-[#1b2430] p-2 text-left shadow-[0_10px_30px_rgba(73,196,229,0.08)] transition hover:-translate-y-0.5 hover:border-[#49c4e5] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#49c4e5] sm:p-3"
+                  >
+                    <span className="block text-[0.68rem] font-semibold leading-snug text-white sm:text-xs">
+                      {FOCUS_TASK}
+                    </span>
+                    <span className="mt-3 flex items-center justify-between gap-1 text-[0.55rem] font-semibold text-[#77d8ee] sm:text-[0.65rem]">
+                      Move to {nextStage}
+                      <span
+                        aria-hidden
+                        className="transition-transform group-hover:translate-x-0.5"
+                      >
+                        →
+                      </span>
+                    </span>
+                  </button>
+                ) : null}
+
+                {supportingTask ? (
+                  <div className="min-h-20 rounded-lg border border-white/[0.06] bg-[#191d26] p-2 sm:p-3">
+                    <p className="text-[0.62rem] font-medium leading-snug text-[#c4cad5] sm:text-[0.7rem]">
+                      {supportingTask.title}
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="sr-only" aria-live="polite">
+        {FOCUS_TASK} is now in {STAGES[stage].name}.
+      </p>
+      <p className="mt-4 px-1 text-[0.68rem] text-[var(--color-dim)]">
+        Click the highlighted task to move it. Every move also has a keyboard and
+        screen-reader path in the full app.
+      </p>
+    </section>
+  );
+}

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { redactAnalyticsRoute } from "./analytics";
+
+describe("redactAnalyticsRoute", () => {
+  it("removes board ids and query parameters", () => {
+    const event = redactAnalyticsRoute({
+      type: "pageview",
+      url: "https://kboards.example/boards/abc123?ref=private",
+    });
+
+    expect(event.url).toBe("https://kboards.example/boards/[board]");
+  });
+
+  it("removes password-reset credentials", () => {
+    const event = redactAnalyticsRoute({
+      type: "pageview",
+      url: "https://kboards.example/password-reset/user-id/secret-token",
+    });
+
+    expect(event.url).toBe(
+      "https://kboards.example/password-reset/[private-link]",
+    );
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,18 @@
+import type { BeforeSendEvent } from "@vercel/analytics/next";
+
+export function redactAnalyticsRoute(
+  event: BeforeSendEvent,
+): BeforeSendEvent {
+  const url = new URL(event.url);
+
+  // Board ids and password-reset credentials do not belong in analytics.
+  url.pathname = url.pathname
+    .replace(/^\/boards\/[^/]+/, "/boards/[board]")
+    .replace(
+      /^\/password-reset\/[^/]+\/[^/]+/,
+      "/password-reset/[private-link]",
+    );
+  url.search = "";
+
+  return { ...event, url: url.toString() };
+}

--- a/lib/board/templates.ts
+++ b/lib/board/templates.ts
@@ -1,0 +1,53 @@
+export const BOARD_TEMPLATE_IDS = ["blank", "personal"] as const;
+export type BoardTemplateId = (typeof BOARD_TEMPLATE_IDS)[number];
+
+const PERSONAL_COLUMNS = [
+  { name: "backlog", color: "#8471f2" },
+  { name: "this week", color: "#49c4e5" },
+  { name: "done", color: "#67e2ae" },
+] as const;
+
+const PERSONAL_TASKS = [
+  {
+    title: "Choose one meaningful outcome",
+    description:
+      "Keep the week small enough to finish. Edit this task with the outcome that matters most.",
+    status: { name: "this week", color: "#49c4e5" },
+    order: 0,
+    subtasks: [
+      { title: "Name the outcome", completed: false },
+      { title: "Define what done means", completed: false },
+    ],
+  },
+  {
+    title: "Capture the rest without committing",
+    description:
+      "Use the backlog for ideas that matter, but do not need your attention today.",
+    status: { name: "backlog", color: "#8471f2" },
+    order: 0,
+    subtasks: [],
+  },
+  {
+    title: "Move this when you finish",
+    description:
+      "Drag this card to Done, or use its actions menu for the same accessible move.",
+    status: { name: "this week", color: "#49c4e5" },
+    order: 1,
+    subtasks: [],
+  },
+] as const;
+
+export function fieldsForBoardTemplate(template: BoardTemplateId) {
+  if (template === "blank") return {};
+
+  // Return fresh plain objects. Mongoose mutates input arrays as it casts them
+  // into subdocuments, so shared template objects must never be passed through.
+  return {
+    columns: PERSONAL_COLUMNS.map((column) => ({ ...column })),
+    tasks: PERSONAL_TASKS.map((task) => ({
+      ...task,
+      status: { ...task.status },
+      subtasks: task.subtasks.map((subtask) => ({ ...subtask })),
+    })),
+  };
+}

--- a/lib/email.test.ts
+++ b/lib/email.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendResetEmail } from "./email";
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  resend: vi.fn(),
+}));
+
+vi.mock("resend", () => ({
+  Resend: class MockResend {
+    emails = { send: mocks.send };
+
+    constructor(apiKey: string) {
+      mocks.resend(apiKey);
+    }
+  },
+}));
+
+beforeEach(() => {
+  vi.stubEnv("EMAIL_FROM", "kboards <hello@example.com>");
+  vi.stubEnv("RESEND_API_KEY", "");
+  vi.stubEnv("SMTP_HOST", "");
+  vi.stubEnv("SMTP_PASS", "");
+  mocks.send.mockReset();
+  mocks.resend.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("sendResetEmail", () => {
+  it("logs the reset link in local development without a provider", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await sendResetEmail("user@example.com", "https://example.com/reset");
+
+    expect(info).toHaveBeenCalledWith(
+      "[email] password reset for user@example.com: https://example.com/reset",
+    );
+    expect(mocks.resend).not.toHaveBeenCalled();
+  });
+
+  it("sends through the Resend API", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    mocks.send.mockResolvedValue({ data: { id: "email-id" }, error: null });
+
+    await sendResetEmail("user@example.com", "https://example.com/reset");
+
+    expect(mocks.resend).toHaveBeenCalledWith("re_test");
+    expect(mocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user@example.com",
+        subject: "Reset your kboards password",
+      }),
+    );
+  });
+
+  it("keeps the existing Resend SMTP key working during migration", async () => {
+    vi.stubEnv("SMTP_HOST", "smtp.resend.com");
+    vi.stubEnv("SMTP_PASS", "re_legacy");
+    mocks.send.mockResolvedValue({ data: { id: "email-id" }, error: null });
+
+    await sendResetEmail("user@example.com", "https://example.com/reset");
+
+    expect(mocks.resend).toHaveBeenCalledWith("re_legacy");
+  });
+
+  it("surfaces provider errors", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    mocks.send.mockResolvedValue({
+      data: null,
+      error: { message: "Domain is not verified" },
+    });
+
+    await expect(
+      sendResetEmail("user@example.com", "https://example.com/reset"),
+    ).rejects.toThrow("Domain is not verified");
+  });
+});

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,28 +1,36 @@
-import nodemailer from "nodemailer";
+import { Resend } from "resend";
 
 const FROM = process.env.EMAIL_FROM || "kboards <no-reply@kboards.local>";
 
-// Sends the password reset link. When SMTP is configured we deliver a real
-// email; otherwise (local dev, CI) we log the link so the flow stays testable
-// end to end without external credentials. Wiring a transactional provider for
-// production is a follow-up (see docs/adr/0004).
-export async function sendResetEmail(to: string, link: string): Promise<void> {
-  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env;
+function resendApiKey(): string | undefined {
+  if (process.env.RESEND_API_KEY) return process.env.RESEND_API_KEY;
 
-  if (!SMTP_HOST) {
+  // Preserve the current production deployment during the SMTP-to-API
+  // migration: Resend's SMTP password is the same API key. This compatibility
+  // path can be removed after RESEND_API_KEY is set in Vercel.
+  if (process.env.SMTP_HOST === "smtp.resend.com") {
+    return process.env.SMTP_PASS;
+  }
+}
+
+// Sends the password reset link through Resend's HTTPS API. When no provider is
+// configured (local development and CI), log the link so the flow remains
+// testable without external credentials.
+export async function sendResetEmail(to: string, link: string): Promise<void> {
+  const apiKey = resendApiKey();
+
+  if (!apiKey) {
+    if (process.env.SMTP_HOST) {
+      throw new Error(
+        "SMTP delivery is no longer supported; configure RESEND_API_KEY",
+      );
+    }
     console.info(`[email] password reset for ${to}: ${link}`);
     return;
   }
 
-  const port = Number(SMTP_PORT) || 587;
-  const transport = nodemailer.createTransport({
-    host: SMTP_HOST,
-    port,
-    secure: port === 465,
-    auth: SMTP_USER ? { user: SMTP_USER, pass: SMTP_PASS } : undefined,
-  });
-
-  await transport.sendMail({
+  const resend = new Resend(apiKey);
+  const { error } = await resend.emails.send({
     from: FROM,
     to,
     subject: "Reset your kboards password",
@@ -30,4 +38,8 @@ export async function sendResetEmail(to: string, link: string): Promise<void> {
       `Reset your kboards password using this link:\n\n${link}\n\n` +
       `This link expires in one hour. If you did not request it, you can ignore this email.`,
   });
+
+  if (error) {
+    throw new Error(`Could not send password reset email: ${error.message}`);
+  }
 }

--- a/lib/services/boards.test.ts
+++ b/lib/services/boards.test.ts
@@ -50,6 +50,25 @@ describe("board CRUD", () => {
     expect(board.columns).toHaveLength(0);
   });
 
+  it("can create a ready-to-use personal board", async () => {
+    const userId = newId();
+    const board = await createBoard(userId, {
+      name: "My week",
+      template: "personal",
+    });
+
+    expect(board.columns.map((column) => column.name)).toEqual([
+      "backlog",
+      "this week",
+      "done",
+    ]);
+    expect(board.tasks).toHaveLength(3);
+    expect(
+      board.tasks.filter((task) => task.status.name === "this week"),
+    ).toHaveLength(2);
+    expect(board.tasks[0].subtasks).toHaveLength(2);
+  });
+
   it("lists only the requesting user's boards", async () => {
     const userId = newId();
     const otherId = newId();

--- a/lib/services/boards.ts
+++ b/lib/services/boards.ts
@@ -1,6 +1,10 @@
 import { isValidObjectId } from "mongoose";
 import { dbConnect } from "@/lib/db/mongoose";
 import { Board } from "@/lib/db/models/Board";
+import {
+  fieldsForBoardTemplate,
+  type BoardTemplateId,
+} from "@/lib/board/templates";
 import { conflict, notFound } from "./errors";
 import { findOwnedBoard, type BoardDocument } from "./access";
 
@@ -33,13 +37,18 @@ export async function getBoard(
 
 export async function createBoard(
   userId: string,
-  input: { name: string; description?: string },
+  input: {
+    name: string;
+    description?: string;
+    template?: BoardTemplateId;
+  },
 ): Promise<BoardDocument> {
   await dbConnect();
   return Board.create({
     createdBy: userId,
     name: input.name,
     description: input.description,
+    ...fieldsForBoardTemplate(input.template ?? "blank"),
   });
 }
 

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { taskReorderSchema } from "./validation";
+import { boardSchema, taskReorderSchema } from "./validation";
+
+describe("boardSchema", () => {
+  it("defaults to a blank template for existing API clients", () => {
+    expect(boardSchema.parse({ name: "Roadmap" }).template).toBe("blank");
+  });
+
+  it("accepts the personal starter template", () => {
+    expect(
+      boardSchema.parse({ name: "My week", template: "personal" }).template,
+    ).toBe("personal");
+  });
+
+  it("rejects unknown templates", () => {
+    expect(() =>
+      boardSchema.parse({ name: "Roadmap", template: "company-secret" }),
+    ).toThrow();
+  });
+});
 
 describe("taskReorderSchema", () => {
   it("accepts a column name and a list of unique task ids", () => {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { BOARD_TEMPLATE_IDS } from "@/lib/board/templates";
 
 // bcrypt only considers the first 72 bytes of a password, so cap input there.
 const password = z
@@ -21,6 +22,7 @@ export const loginSchema = z.object({
 export const boardSchema = z.object({
   name: z.string().min(1).max(25),
   description: z.string().min(3).max(100).optional(),
+  template: z.enum(BOARD_TEMPLATE_IDS).default("blank"),
 });
 
 // Boards can be renamed or re-described; require at least one field to change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,51 @@
 {
   "name": "kboards",
-  "version": "2.0.0-dev",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kboards",
-      "version": "2.0.0-dev",
+      "version": "2.1.0",
       "dependencies": {
-        "@auth/mongodb-adapter": "^3.11.2",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@vercel/analytics": "^2.0.1",
         "bcryptjs": "^3.0.3",
         "mongodb": "^6.21.0",
         "mongoose": "^9.7.2",
-        "next": "16.2.9",
-        "next-auth": "^5.0.0-beta.31",
-        "nodemailer": "^7.0.13",
+        "next": "^16.2.12",
+        "next-auth": "^5.0.0-beta.32",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "resend": "^6.18.0",
         "sonner": "^2.0.7",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.1.0",
         "@commitlint/config-conventional": "^21.1.0",
-        "@tailwindcss/postcss": "^4",
+        "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
-        "@types/nodemailer": "^8.0.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "axe-core": "^4.12.1",
         "eslint": "^9",
-        "eslint-config-next": "16.2.9",
+        "eslint-config-next": "16.2.12",
         "husky": "^9.1.7",
         "jsdom": "^25.0.1",
         "lint-staged": "^17.0.8",
+        "postcss": "^8.5.23",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -87,9 +90,9 @@
       "license": "ISC"
     },
     "node_modules/@auth/core": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
-      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
+      "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -101,7 +104,7 @@
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^7.0.7"
+        "nodemailer": "^7.0.7 || ^8.0.5"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {
@@ -113,18 +116,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@auth/mongodb-adapter": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/@auth/mongodb-adapter/-/mongodb-adapter-3.11.2.tgz",
-      "integrity": "sha512-3yKYvPB/7NjDN5VW6iymEdQEKQOezqVpev4heAhN+zxz5G/jOIQdxBu8iF8nIomF8ggY+FRDqysSNwb72JM6dw==",
-      "license": "ISC",
-      "dependencies": {
-        "@auth/core": "0.41.2"
-      },
-      "peerDependencies": {
-        "mongodb": "^6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1137,9 +1128,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1149,19 +1140,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1171,19 +1162,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1197,9 +1207,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1213,9 +1223,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1232,9 +1242,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1251,9 +1261,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1270,9 +1280,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1289,9 +1299,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1308,9 +1318,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1327,9 +1337,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1346,9 +1356,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1365,9 +1375,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1380,19 +1390,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1405,19 +1415,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1430,19 +1440,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1455,19 +1465,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1480,19 +1490,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1505,19 +1515,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1530,19 +1540,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1555,38 +1565,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1596,16 +1622,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1615,16 +1641,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1634,7 +1660,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1719,15 +1745,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.9.tgz",
-      "integrity": "sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.12.tgz",
+      "integrity": "sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1735,9 +1761,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1751,9 +1777,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1767,9 +1793,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
       ],
@@ -1786,9 +1812,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
       ],
@@ -1805,9 +1831,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
       ],
@@ -1824,9 +1850,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
       ],
@@ -1843,9 +1869,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1859,9 +1885,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -2282,6 +2308,12 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2299,49 +2331,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.1"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-x64": "4.3.1",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
-      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -2356,9 +2388,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -2373,9 +2405,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
-      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -2390,9 +2422,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
-      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -2407,9 +2439,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
-      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -2424,9 +2456,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
-      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -2444,9 +2476,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
-      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -2464,9 +2496,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
-      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -2484,9 +2516,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
-      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -2504,9 +2536,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
-      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2522,9 +2554,9 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
         "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
@@ -2534,9 +2566,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
-      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -2551,9 +2583,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
-      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -2568,17 +2600,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
-      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.1",
-        "@tailwindcss/oxide": "4.3.1",
-        "postcss": "8.5.15",
-        "tailwindcss": "4.3.1"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -2748,16 +2780,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/nodemailer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
-      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -2981,29 +3003,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3443,6 +3442,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
@@ -3907,11 +3948,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
@@ -3935,14 +3979,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4662,9 +4708,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5021,13 +5067,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.9.tgz",
-      "integrity": "sha512-olGtBrs07bQchpaJWeqbk9GaMoU0oGmN/pYNEBXSbfgKngb5uHnPe37X6tVeh6DJfaWFQildvinGEOrolo5fmw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.12.tgz",
+      "integrity": "sha512-iaaf4vvKo5h2LBdGt0JuRv7t0Ysqr9FMCiFxbptDg8LqOE//mIKR80DdpOnSVM7qjLH3jT8P0aFiwXxBEGZRXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.9",
+        "@next/eslint-plugin-next": "16.2.12",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5444,10 +5490,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -6616,9 +6668,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6632,9 +6684,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -7425,6 +7477,24 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -7614,9 +7684,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7655,12 +7725,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -7674,14 +7744,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -7708,18 +7778,18 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
-      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "version": "5.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.32.tgz",
+      "integrity": "sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.2"
+        "@auth/core": "0.41.3"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
         "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
-        "nodemailer": "^7.0.7",
+        "nodemailer": "^7.0.7 || ^8.0.5",
         "react": "^18.2.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -7732,34 +7802,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {
@@ -7789,15 +7831,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nwsapi": {
@@ -8145,11 +8178,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8166,7 +8204,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8388,6 +8426,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.0.tgz",
+      "integrity": "sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -8675,48 +8734,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
@@ -8928,6 +8992,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -9200,9 +9274,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,40 +16,50 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@auth/mongodb-adapter": "^3.11.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@vercel/analytics": "^2.0.1",
     "bcryptjs": "^3.0.3",
     "mongodb": "^6.21.0",
     "mongoose": "^9.7.2",
-    "next": "16.2.9",
-    "next-auth": "^5.0.0-beta.31",
-    "nodemailer": "^7.0.13",
+    "next": "^16.2.12",
+    "next-auth": "^5.0.0-beta.32",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "resend": "^6.18.0",
     "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.1.0",
     "@commitlint/config-conventional": "^21.1.0",
-    "@tailwindcss/postcss": "^4",
+    "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
-    "@types/nodemailer": "^8.0.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "axe-core": "^4.12.1",
     "eslint": "^9",
-    "eslint-config-next": "16.2.9",
+    "eslint-config-next": "16.2.12",
     "husky": "^9.1.7",
     "jsdom": "^25.0.1",
     "lint-staged": "^17.0.8",
+    "postcss": "^8.5.23",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.9"
+  },
+  "overrides": {
+    "minimatch@3.1.5": {
+      "brace-expansion": "1.1.16"
+    },
+    "minimatch@10.2.5": {
+      "brace-expansion": "5.0.8"
+    },
+    "postcss": "$postcss",
+    "sharp": "0.35.3"
   }
 }


### PR DESCRIPTION
## What changed

- Replaces the minimal landing page with a product-led, responsive experience centered on an accessible interactive board preview.
- Adds an opt-in Personal board template with Backlog, This week, Done, and editable starter prompts; direct API clients still default to blank boards.
- Adds anonymous Vercel Web Analytics with board ids, password-reset credentials, and query parameters redacted before transmission.
- Updates Next.js and Auth.js to patched releases, removes the unused Auth MongoDB adapter, and pins patched PostCSS/Sharp transitive versions.
- Replaces Nodemailer/SMTP with the Resend Email API while temporarily accepting the existing Resend SMTP key configuration.

## Why

The v2 rebuild was technically ready but had no activation loop. This tranche lets visitors experience the product before registration and gets new users to a useful first board with less setup.

## Product and technical tradeoffs

- The create-board UI defaults to the Personal template, but users can choose Blank and existing API clients remain backward compatible.
- Vercel Web Analytics must be enabled in the project dashboard before page views appear. This PR intentionally avoids paid-plan custom events.
- `SMTP_HOST=smtp.resend.com` plus `SMTP_PASS` remains a compatibility fallback; move the same key to `RESEND_API_KEY` after merge.
- `npm audit --omit=dev` reports zero vulnerabilities. The full development tree still reports the upstream ESLint/minimatch brace-expansion advisory; forcing one brace-expansion major globally broke ESLint, so the compatible patched majors are scoped instead.

## Validation

- `npm run lint`
- `npm run typecheck`
- `MONGODB_URI=mongodb://localhost:27017/kboards-test npm test` — 124/124 passing
- `npm run build`
- `npm audit --omit=dev` — 0 vulnerabilities
- Playwright desktop and 390px mobile visual checks
- Interactive preview behavior and live-region announcement verified in browser
- Browser console: 0 errors, 0 warnings

## Manual follow-up after merge

- Enable Web Analytics in Vercel.
- Add `RESEND_API_KEY` in Vercel and retire the legacy SMTP variables after confirming password-reset delivery.
