### PR TITLE
feat(growth): open first board after signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Optional Personal-flow board template with Backlog, This week, and Done
   columns plus editable starter prompts; existing API clients continue to create
   blank boards by default.
+- New accounts now open directly on a ready-to-edit Personal board, with the
+  existing empty state retained as a safe fallback if starter setup is
+  temporarily unavailable.
 - Privacy-redacted Vercel Web Analytics integration. Board identifiers,
   password-reset credentials, and query parameters are removed before page-view
   events are sent.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ iteration" portfolio project. The rebuild is tracked visibly through commits, AD
 - **Authentication** — email/password (Auth.js v5, Credentials + JWT sessions) with a custom
   password-reset flow whose tokens are stored only as SHA-256 hashes and are single-use.
 - **Responsive** — a board-list sidebar that becomes a slide-over drawer on small screens.
-- **Fast first board** — start blank or choose a Personal flow with Backlog, This week, and Done
-  columns plus editable prompts.
+- **Fast first board** — new accounts open on a ready-to-edit Personal flow with Backlog,
+  This week, and Done; later boards can start Personal or blank.
 - **Product-led preview** — visitors can move a task through a real interactive board preview
   before creating an account.
 

--- a/app/(auth)/register/RegisterForm.test.tsx
+++ b/app/(auth)/register/RegisterForm.test.tsx
@@ -26,15 +26,22 @@ beforeEach(() => {
 async function fillAndSubmit(email: string, password: string) {
   await userEvent.type(screen.getByLabelText("Email"), email);
   await userEvent.type(screen.getByLabelText("Password"), password);
-  await userEvent.click(screen.getByRole("button", { name: /create account/i }));
+  await userEvent.click(
+    screen.getByRole("button", { name: /create account & board/i }),
+  );
 }
 
 describe("RegisterForm", () => {
-  it("registers, signs in, and redirects on success", async () => {
-    fetchMock.mockResolvedValue({
+  it("registers, signs in, and opens a personal starter board", async () => {
+    fetchMock.mockResolvedValueOnce({
       ok: true,
       status: 201,
       json: async () => ({ user: {} }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ board: { id: "board-1" } }),
     });
     signInMock.mockResolvedValue({ ok: true, error: undefined });
     render(<RegisterForm />);
@@ -46,6 +53,33 @@ describe("RegisterForm", () => {
       expect.objectContaining({ method: "POST" }),
     );
     expect(signInMock).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/boards",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "My week", template: "personal" }),
+      }),
+    );
+    expect(push).toHaveBeenCalledWith("/boards/board-1");
+  });
+
+  it("falls back to the empty state if starter-board creation fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ user: {} }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "unavailable" }),
+    });
+    signInMock.mockResolvedValue({ ok: true, error: undefined });
+    render(<RegisterForm />);
+
+    await fillAndSubmit("new@example.com", "supersecret");
+
     expect(push).toHaveBeenCalledWith("/boards");
   });
 
@@ -64,6 +98,21 @@ describe("RegisterForm", () => {
     );
     expect(signInMock).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
+  });
+
+  it("sends a new account to sign in if automatic sign-in fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ user: {} }),
+    });
+    signInMock.mockResolvedValue({ ok: false, error: "CredentialsSignin" });
+    render(<RegisterForm />);
+
+    await fillAndSubmit("new@example.com", "supersecret");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith("/login");
   });
 
   it("validates password length before calling the API", async () => {

--- a/app/(auth)/register/RegisterForm.tsx
+++ b/app/(auth)/register/RegisterForm.tsx
@@ -6,6 +6,8 @@ import { signIn } from "next-auth/react";
 import { TextField } from "@/components/ui/TextField";
 import { Button } from "@/components/ui/Button";
 import { FormStatus } from "@/components/ui/FormStatus";
+import { apiFetch } from "@/lib/api/client";
+import type { BoardDTO } from "@/lib/dto";
 
 export function RegisterForm() {
   const router = useRouter();
@@ -44,7 +46,8 @@ export function RegisterForm() {
         return;
       }
 
-      // Account created: sign in so the user lands straight on their boards.
+      // Account created: sign in, then fulfill the landing-page promise by
+      // opening a useful Personal board instead of another setup screen.
       const result = await signIn("credentials", {
         email,
         password,
@@ -55,7 +58,21 @@ export function RegisterForm() {
         router.push("/login");
         return;
       }
-      router.push("/boards");
+
+      let destination = "/boards";
+      try {
+        const { board } = await apiFetch<{ board: BoardDTO }>("/api/boards", {
+          method: "POST",
+          body: { name: "My week", template: "personal" },
+        });
+        destination = `/boards/${board.id}`;
+      } catch {
+        // The account and session are already valid. Fall back to the existing
+        // empty state so a transient board-creation failure never strands the
+        // new user or asks them to register again.
+      }
+
+      router.push(destination);
       router.refresh();
     } catch {
       setError("Something went wrong. Please try again.");
@@ -92,7 +109,7 @@ export function RegisterForm() {
         placeholder="At least 8 characters"
       />
       <Button type="submit" loading={pending}>
-        Create account
+        Create account &amp; board
       </Button>
     </form>
   );

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -12,8 +12,8 @@ export default async function RegisterPage() {
 
   return (
     <AuthCard
-      title="Create an account"
-      subtitle="Start tracking your work in minutes."
+      title="Start your board"
+      subtitle="Create your account and open a ready-to-edit Personal flow."
       footer={
         <>
           Already have an account?{" "}


### PR DESCRIPTION
## Problem

The landing CTA promises “Start a personal board,” but registration still ended at an empty state and required another setup action.

## Approach

- Create a ready-to-edit Personal board immediately after automatic sign-in.
- Land the new user directly on that board.
- Fall back to the existing empty state if board creation is temporarily unavailable.
- Keep failed automatic sign-in routed to the normal sign-in page.
- Align registration copy, README, and changelog with the activation flow.

## Tradeoffs / alternatives considered

Creating the board in the registration API would couple account creation to a second database write and complicate rollback if board creation failed. Creating it after the session exists keeps account creation durable and makes the fallback recoverable without asking the user to register again.

## Testing

- `npx vitest run 'app/(auth)/register/RegisterForm.test.tsx'` — 5/5 passing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

CodeRabbit's hosted PR review allowance is currently rate-limited. This tranche is small, covered by focused success and failure-path tests, and has been reviewed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New accounts now open directly to a ready-to-edit Personal board with Backlog, This week, and Done columns.
  * Registration messaging and button labels now reflect board creation.
  * Additional boards can still begin with either a Personal setup or a blank board.

* **Bug Fixes**
  * If starter-board creation is unavailable, registration falls back to the standard boards view.
  * If automatic sign-in fails, users are redirected to the login page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->